### PR TITLE
Add fallback for extracting times from irregular original xml

### DIFF
--- a/lib/hansard_rewriter.rb
+++ b/lib/hansard_rewriter.rb
@@ -162,6 +162,15 @@ EOF
           # Rip out the start time
           # <span class="HPS-Time">09:27</span>
           time = p.search("//span[@class=HPS-Time]")
+          if time.inner_html =~ /\d+:\d\d/
+            ripped_out_time = time.inner_html
+          else
+            # We've got a badly formed date, let's try something else
+            fallback = p.inner_html.match(/(\d+):*<span class="HPS-Time">:*(\d\d)<\/span>/mi)
+            if fallback
+              ripped_out_time = fallback[1] + ':' + fallback[2]
+            end
+          end
           time.remove
 
           # Pull out the name
@@ -185,7 +194,7 @@ EOF
           new_node = <<EOF
 <speech>
   <talker>
-    <time.stamp>#{time.inner_text}</time.stamp>
+    <time.stamp>#{ripped_out_time}</time.stamp>
     <name role="metadata">#{name}</name>
     <name.id>#{aph_id}</name.id>
     <electorate>#{electorate.inner_text}</electorate>

--- a/spec/fixtures/bad-dates.xml
+++ b/spec/fixtures/bad-dates.xml
@@ -1,0 +1,141 @@
+<hansard noNamespaceSchemaLocation="../../hansard.xsd" version="2.2">
+  <session.header>
+    <date>2012-10-29</date>
+    <parliament.no>43</parliament.no>
+    <session.no>1</session.no>
+    <period.no>7</period.no>
+    <chamber>Senate</chamber>
+    <page.no>0</page.no>
+    <proof>1</proof>
+  </session.header>
+  <chamber.xscript>
+    <business.start>
+      <body background="" style="" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:WX="http://schemas.microsoft.com/office/word/2003/auxHint" xmlns:aml="http://schemas.microsoft.com/aml/2001/core" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+        <p class="HPS-SODJobDate" style="direction:ltr;unicode-bidi:normal;">
+          <span class="HPS-SODJobDate">
+            <span style="font-weight:bold;" />
+            <a href="Chamber" type="">Monday, 29 October 2012</a>
+          </span>
+        </p>
+        <p class="HPS-Normal" style="direction:ltr;unicode-bidi:normal;">
+          <span class="HPS-Normal">
+            <span style="font-weight:bold;">The PRESIDENT</span>
+            <span style="font-weight:bold;">(Senator the Hon. John Hogg) </span>took the chair at 10:00<span class="HPS-JobStartTimeChar" style="&#xD;&#xA;    font-family:;&#xD;&#xA;  ">,</span> read prayers and made an acknowledgement of country.</span>
+        </p>
+        <p class="HPS-Line" style="direction:ltr;unicode-bidi:normal;">
+          <span class="HPS-Line"> </span>
+        </p>
+      </body>
+    </business.start>
+    <debate>
+      <debateinfo>
+        <title>CONDOLENCES</title>
+        <page.no>1</page.no>
+        <type>CONDOLENCES</type>
+      </debateinfo>
+      <debate.text>
+        <body background="" style="" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:WX="http://schemas.microsoft.com/office/word/2003/auxHint" xmlns:aml="http://schemas.microsoft.com/aml/2001/core" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+          <p class="HPS-Debate" style="direction:ltr;unicode-bidi:normal;">
+            <span class="HPS-Debate">CONDOLENCES</span>
+          </p>
+        </body>
+      </debate.text>
+      <subdebate.1>
+        <subdebateinfo>
+          <title>Smith, Corporal Scott James</title>
+          <page.no>1</page.no>
+        </subdebateinfo>
+        <subdebate.text>
+          <body background="" style="" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:WX="http://schemas.microsoft.com/office/word/2003/auxHint" xmlns:aml="http://schemas.microsoft.com/aml/2001/core" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+            <p class="HPS-SubDebate" style="direction:ltr;unicode-bidi:normal;">
+              <span class="HPS-SubDebate">Smith, Corporal Scott James</span>
+            </p>
+          </body>
+        </subdebate.text>
+        <speech>
+          <talk.start>
+            <talker>
+              <page.no>1</page.no>
+              <time.stamp />
+              <name role="metadata">Evans, Sen Christopher</name>
+              <name.id>AX5</name.id>
+              <electorate />
+              <party>ALP</party>
+              <in.gov />
+              <first.speech />
+            </talker>
+          </talk.start>
+          <talk.text>
+            <body background="" style="" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:WX="http://schemas.microsoft.com/office/word/2003/auxHint" xmlns:aml="http://schemas.microsoft.com/aml/2001/core" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+              <p class="HPS-Normal" style="direction:ltr;unicode-bidi:normal;">
+                <span class="HPS-Normal">
+                  <a href="AX5" type="MemberSpeech">
+                    <span class="HPS-MemberSpeech">Senator CHRIS EVANS</span>
+                  </a> (<span class="HPS-Electorate">Western Australia</span>—<span class="HPS-MinisterialTitles">Minister for Tertiary Education, Skills, Science and Research and Leader of the Government in the Senate</span>) (10<span class="HPS-Time">:01</span>): I seek leave to move a motion relating to the death of Corporal Scott James Smith.</span>
+              </p>
+              <p class="HPS-Normal" style="direction:ltr;unicode-bidi:normal;">
+                <span class="HPS-Normal">Leave granted. </span>
+              </p>
+              <p class="HPS-Normal" style="direction:ltr;unicode-bidi:normal;">
+                <span class="HPS-Normal">
+                  <a href="AX5" type="MemberContinuation">
+                    <span class="HPS-MemberContinuation">Senator CHRIS EVANS:</span>
+                  </a>  I move:</span>
+              </p>
+              <p class="HPS-Small" style="direction:ltr;unicode-bidi:normal;">
+                <span class="HPS-Small">That the Senate records its deep sorrow at the death, on 21 October 2012, of Corporal Scott James Smith, while on combat operations in Afghanistan, places on record its appreciation of his service to our country, and tenders its profound sympathy to his family, friends and colleagues in their bereavement.</span>
+              </p>
+              <p class="HPS-Normal" style="direction:ltr;unicode-bidi:normal;">
+                <span class="HPS-Normal">
+                  <a href="7L6" type="OfficeContinuation">
+                    <span class="HPS-OfficeContinuation">The PRESIDENT:</span>
+                  </a>  I ask senators to stand in silence to signify their assent to the motion.</span>
+              </p>
+              <p class="HPS-Normal" style="direction:ltr;unicode-bidi:normal;">
+                <span class="HPS-Normal">
+                  <span style="font-style:italic;" />
+                  <span style="font-style:italic;">Honourable senators having stood in their places—</span>
+                </span>
+              </p>
+              <p class="HPS-Normal" style="direction:ltr;unicode-bidi:normal;">
+                <span class="HPS-Normal">Question agreed to.  </span>
+              </p>
+            </body>
+          </talk.text>
+          <continue>
+            <talk.start>
+              <talker>
+                <page.no>1</page.no>
+                <time.stamp />
+                <name role="metadata">Evans, Sen Christopher</name>
+                <name.id>AX5</name.id>
+                <electorate />
+                <party>ALP</party>
+                <in.gov />
+                <first.speech />
+              </talker>
+            </talk.start>
+            <talk.text>
+            </talk.text>
+          </continue>
+          <continue>
+            <talk.start>
+              <talker>
+                <page.no>1</page.no>
+                <time.stamp />
+                <name role="metadata">PRESIDENT, The</name>
+                <name.id>10000</name.id>
+                <electorate />
+                <party />
+                <in.gov />
+                <first.speech />
+              </talker>
+            </talk.start>
+            <talk.text>
+            </talk.text>
+          </continue>
+        </speech>
+      </subdebate.1>
+    </debate>
+  </chamber.xscript>
+</hansard>

--- a/spec/hansard_rewriter_spec.rb
+++ b/spec/hansard_rewriter_spec.rb
@@ -1,0 +1,17 @@
+require 'hansard_rewriter'
+require 'log4r'
+
+describe HansardRewriter do
+
+  describe "with speeches containing xml like '(10<span class=\"HPS-Time\">:01</span>):' " do
+
+    let!(:bad_xml){ File.open("#{File.dirname(__FILE__)}/fixtures/bad-dates.xml").read }
+    let!(:rewriter){ HansardRewriter.new(Log4r::Logger.new('TestHansardParser')) }
+    let!(:rewritten_xml){ rewriter.rewrite_xml(Hpricot.XML(bad_xml)) }
+
+    it "should correctly rewrite the date to the time.stamp tag" do
+      # hpricot can't handle xpaths with periods in them, so just use regex
+      rewritten_xml.at('talker').inner_html.should =~ /<time\.stamp>10:01<\/time\.stamp>/
+    end
+  end
+end


### PR DESCRIPTION
Added a fallback for extracting times from screwed up markup like: `(10<span class="HPS-Time">:01</span>):`.

`grep -rni HPS-Time origxml | grep -v '[0-9]\{1,2\}:[0-9]\{2\}'` gives you a rough estimate of how many messed up times there are. This fix works for quite a few of them but not all of them.
