### PR TITLE
Fixes for importing older data

### DIFF
--- a/lib/debates.rb
+++ b/lib/debates.rb
@@ -90,7 +90,12 @@ class Debates
   def calculate_speech_durations
     @items.each_with_index do |section, index|
 
-      next unless section.is_a?(Speech) && section.time
+      next unless section.is_a?(Speech)
+
+      if !section.time
+        section.duration = 0
+        next
+      end
 
       # Interjections are skipped
       if section.interjection || section.continuation
@@ -104,8 +109,12 @@ class Debates
       end
 
       # Scan ahead looking for the next section (skipping sections without time
-      # or interjections or continuations)
+      # or interjections or continuations). Also keep track of how many words
+      # were used in continuations
       next_section = @items[(index + 1)..-1].detect{|next_item|
+        if next_item.is_a?(Speech) && next_item.continuation
+          section.word_count_for_continuations += next_item.words  
+        end
         next_item.is_a?(Speech) && next_item.time && !next_item.interjection && !next_item.continuation
       }
 
@@ -113,7 +122,7 @@ class Debates
       if next_section
         section.duration = next_section.to_time - section.to_time
       else
-        break
+        section.duration = 0
       end
     end
   end

--- a/lib/speech.rb
+++ b/lib/speech.rb
@@ -4,12 +4,14 @@ require 'htmlentities'
 require 'section'
 
 class Speech < Section
-  attr_accessor :speaker, :content, :interjection, :continuation, :duration
+  attr_accessor :speaker, :content, :interjection, :continuation, :duration,
+    :word_count_for_continuations
   
   def initialize(speaker, time, url, count, date, house, logger = nil)
     @speaker = speaker
     @content = Hpricot::Elements.new
     @duration = 0
+    @word_count_for_continuations = 0
     super(time, url, count, date, house, logger)
   end
   
@@ -55,12 +57,20 @@ class Speech < Section
     end
   end
 
-  def duration=(duration)
-    # Cleanup up durations less than zero or greater than 3 hours
-    if (duration < 0 || duration > 3 * 60 * 60) 
-      duration = 0
+  def duration=(duration_estimate)
+    # Cleanup up durations less than zero
+    if (duration_estimate < 0) 
+      duration_estimate = 0
     end
-    @duration = duration
+    if !interjection && !continuation
+      # If the duration seems to be off the word count estimate by more than 10
+      # minutes, fallback to the wordcount estimate
+      duration_from_wordcount = ((words + word_count_for_continuations) / 120).round * 60;
+      if (duration_estimate - duration_from_wordcount).abs > 600
+        duration_estimate = duration_from_wordcount
+      end
+    end
+    @duration = duration_estimate
   end
 
   # Returns adjournment time if the debate was adjourned during the speech

--- a/spec/debates_spec.rb
+++ b/spec/debates_spec.rb
@@ -225,13 +225,32 @@ EOF
     describe "a speech without a time (this rarely occurs but somtimes the xml is that broken)" do
 
       before do
-        @debates.add_speech(@james, nil, "url", Hpricot("<p>This is a speech</p>"))
+        @html = "<p>This is a speech</p>" * (121 * 3) # over 10 minutes of words
+        @debates.add_speech(@james, nil, "url", Hpricot(@html))
         @debates.add_speech(@henry, "9:08", "url", Hpricot("<p>And a bit more</p>"))
         @debates.calculate_speech_durations
       end
 
-      it "should not have a duration set" do
-        @debates.items[0].duration.should be_zero
+      it "should fallback to an estimate based on word count / 120 (the number of words spoken per minute)" do
+        @debates.items[0].duration.should == (121 * 4 * 3 / 120).round * 60
+      end
+
+    end
+
+    describe "a speech followed by a continuation" do
+
+      before do
+        # Add a speech with only 1 minute of words
+        @debates.add_speech(@james, "9:08", "url", Hpricot("test " * 120))
+        # Add an interjection
+        @debates.add_speech(@henry, "9:08", "url", Hpricot("<p>And a bit more</p>"), true)
+        # Add a continuation with 10 minutes of words
+        @debates.add_speech(@james, "9:08", "url", Hpricot("test " * (120 * 10)), false, true)
+        @debates.calculate_speech_durations
+      end
+
+      it "should should use speech.word_count_for_continuations when estimating the duration" do
+        @debates.items[0].duration.should == (11 * 60)
       end
 
     end

--- a/spec/speech_spec.rb
+++ b/spec/speech_spec.rb
@@ -70,6 +70,20 @@ describe Speech do
 
     end
 
+    describe "with a duration that is more than 10 minutes out from an estimate of " +
+             "duration made by taking the word count / 120 (average words per minute people speak at) * 60"  do
+
+      subject{ Speech.new(member, "09:00:00", 'url', Count.new(3, 1), Date.new(2006, 1, 1), House.representatives) }
+      let!(:minutes_by_wordcount){ 12 }
+      let!(:html){ (120 * minutes_by_wordcount).times.map{ "<i>word</i>" }.join(" ") }
+      before do
+        subject.append_to_content(Hpricot(html))
+        subject.duration = 60
+      end
+      its(:duration){ should == minutes_by_wordcount * 60 }
+
+    end
+
   end
 
 


### PR DESCRIPTION
1st commit is a bugfix to handling speeches without times. 

2nd commit improves the estimates of duration by falling back to estimating the time by taking the word count and assuming the speaker is talking at 120 words per minute. This estimate is useful when the time data is corrupted or when it's difficult to work out how long the speech went for (e.g. there was an undetected adjournment).
