### PR TITLE
Updates to Bob Carr and Kerry O'Brien's terms

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -167,7 +167,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 165,,Belinda Jane Neal,,NSW,8.3.1994,section_15,3.9.1998 ,resigned,ALP
 166,,Laurence William Neal,,Vic.,11.3.1980 ,section_15,30.6.1981 ,defeated,NCP
 168,,Jocelyn Margaret Newman,,Tas.,13.3.1986 ,section_15,1.2.2002 ,resigned,LIB
-169,,Kerry Williams Kelso O'Brien,,Tas.,5.9.1996,section_15,,still_in_office,ALP
+169,,Kerry Williams Kelso O'Brien,,Tas.,5.9.1996,section_15,30.6.2011,retired,ALP
 170,,Justin Hilary O'Byrne,,Tas.,1.7.1947 ,,30.6.1981 ,retired,ALP
 171,,William George O'Chee,,Qld,8.5.1990 ,section_15,30.6.1999 ,defeated,NPA
 172,,John Wayne Olsen,,SA,7.5.1990 ,section_15,4.5.1992 ,resigned,LIB
@@ -297,7 +297,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 298,,Larissa Waters,,Queensland,1.7.2011,,,still_in_office,GRN
 300,,Penny Wright,,SA,1.7.2011,,,still_in_office,GRN
 301,,Arthur Sinodinos,,NSW,31.10.2011,section_15,,still_in_office,LIB
-302,,Robert John Carr,,NSW,06.03.2012,,,still_in_office,ALP
+302,,Robert John Carr,,NSW,06.03.2012,,24.10.13,resigned,ALP
 303,,Dean Smith,,WA,2.5.2012,,,still_in_office,LIB
 304,,Lin Estelle Thorp,,Tas.,20.6.2012,,,still_in_office,ALP
 305,,Peter Stuart Whish-Wilson,,Tas.,20.06.2012,,,still_in_office,GRN


### PR DESCRIPTION
Kerry O'Brien retired in 2011
http://parlinfo.aph.gov.au/parlInfo/search/display/display.w3p\;query\=%28Id:handbook/allmps/8o6%29\;rec\=0\;
Bob Carr resigned in 2013
http://parlinfo.aph.gov.au/parlInfo/search/display/display.w3p\;adv\=yes\;orderBy\=customrank\;page\=0\;query\=Id%3A%22handbook%2Fallmps%2FWX4%22\;rec\=0\;resCount\=Default
