### PR TITLE
Fix for image download for mps with hyphenated last names

### DIFF
--- a/lib/name.rb
+++ b/lib/name.rb
@@ -48,6 +48,9 @@ class Name
       last = names[0..1].join(' ')
       names.shift
       names.shift
+    # Check for hyphenated last names
+    elsif names[1] == '-'
+      last = names.shift(3).join
     else
       last = names.shift
     end

--- a/lib/name.rb
+++ b/lib/name.rb
@@ -84,6 +84,7 @@ class Name
     # HACK: Added specific handling for initials DJC, DGH
     if initials_with_fullstops(name)
       initials_with_fullstops(name)
+    # Heuristic: If word is all caps we'll assume that these are initials
     elsif (name.upcase == name)
       name
     elsif (name != "Ed" && name != "Jo" && name.size <= 2) || name == "DJC" || name == "DGH"

--- a/lib/name.rb
+++ b/lib/name.rb
@@ -85,9 +85,10 @@ class Name
     if initials_with_fullstops(name)
       initials_with_fullstops(name)
     # Heuristic: If word is all caps we'll assume that these are initials
-    elsif (name.upcase == name)
+    # HACK: unless it is "-", which could be part of a hyphenated name in specific case
+    elsif (name.upcase == name) && name != "-"
       name
-    elsif (name != "Ed" && name != "Jo" && name.size <= 2) || name == "DJC" || name == "DGH"
+    elsif (name != "Ed" && name != "Jo" && name != "-" && name.size <= 2) || name == "DJC" || name == "DGH"
       name
     end
   end

--- a/spec/name_spec.rb
+++ b/spec/name_spec.rb
@@ -13,13 +13,13 @@ describe Name do
       expect(Name.initials("John.Lawrence")).to eq "JohnLawrence"
     end
 
-    it "returns the full string if it is all caps" do
+    it "returns the full string if it is all-caps" do
       expect(Name.initials("XS")).to eq "XS"
       expect(Name.initials("ALLCAPSWHENYASPELLMANAME")).to eq "ALLCAPSWHENYASPELLMANAME"
       expect(Name.initials("YOUNG")).to eq "YOUNG"
     end
 
-    it "returns the string if it is all non-letter character" do
+    it "returns the string if it is all non-letter characters" do
       expect(Name.initials("1234")).to eq "1234"
       expect(Name.initials("–")).to eq "–"
     end

--- a/spec/name_spec.rb
+++ b/spec/name_spec.rb
@@ -5,6 +5,51 @@ require "test/unit"
 require "name"
 
 describe Name do
+  describe '.initials' do
+    it "returns the string with stops deleted if it includes a fullstop" do
+      expect(Name.initials("X.S")).to eq "XS"
+      expect(Name.initials("X.S.")).to eq "XS"
+      # Do we really want this?
+      expect(Name.initials("John.Lawrence")).to eq "JohnLawrence"
+    end
+
+    it "returns the full string if it is all caps" do
+      expect(Name.initials("XS")).to eq "XS"
+      expect(Name.initials("ALLCAPSWHENYASPELLMANAME")).to eq "ALLCAPSWHENYASPELLMANAME"
+      expect(Name.initials("YOUNG")).to eq "YOUNG"
+    end
+
+    it "returns the string if it is all non-letter character" do
+      expect(Name.initials("1234")).to eq "1234"
+      expect(Name.initials("–")).to eq "–"
+    end
+
+    it "returns nil if it is a specific two letter name (Ed or Jo)" do
+      expect(Name.initials("Ed")).to eq nil
+      expect(Name.initials("Jo")).to eq nil
+      expect(Name.initials("Xi")).not_to eq nil
+    end
+
+    it "returns the string if it is a specific three letter string (DJC or DGH)" do
+      expect(Name.initials("DJC")).to eq "DJC"
+      expect(Name.initials("DGH")).to eq "DGH"
+    end
+
+    it "returns the string if it is two characters or shorter" do
+      expect(Name.initials("xs")).to eq "xs"
+      expect(Name.initials("Ah")).to eq "Ah"
+      expect(Name.initials("1h")).to eq "1h"
+      expect(Name.initials("b")).to eq "b"
+      expect(Name.initials("")).to eq ""
+    end
+
+    it "returns nil if it is longer than two character" do
+      expect(Name.initials("AMcH")).to eq nil
+      expect(Name.initials("Zhang")).to eq nil
+      expect(Name.initials("Young")).to eq nil
+    end
+  end
+
   describe '.last_title_first' do
     it 'parses non-hypenated first names' do
       name = Name.last_title_first("  BROWN  ,   Robert   (Bob)   James  ")

--- a/spec/name_spec.rb
+++ b/spec/name_spec.rb
@@ -102,5 +102,12 @@ describe Name do
       name.middle.should == 'Coral'
       name.last.should == 'Hanson-Young'
     end
+
+    it 'parses hyphenated last names' do
+      name = Name.last_title_first("  KAKOSCHKE  -  MOORE  ,   Skye  ")
+      name.first.should == 'Skye'
+      name.middle.should == ""
+      name.last.should == 'Kakoschke-Moore'
+    end
   end
 end

--- a/spec/name_spec.rb
+++ b/spec/name_spec.rb
@@ -21,7 +21,10 @@ describe Name do
 
     it "returns the string if it is all non-letter characters" do
       expect(Name.initials("1234")).to eq "1234"
-      expect(Name.initials("–")).to eq "–"
+    end
+
+    it "returns nil if it is a specific non-letter character" do
+      expect(Name.initials("-")).to eq nil
     end
 
     it "returns nil if it is a specific two letter name (Ed or Jo)" do

--- a/spec/name_spec.rb
+++ b/spec/name_spec.rb
@@ -64,5 +64,12 @@ describe Name do
       name.middle.should == 'Margaret'
       name.last.should == 'Kelly'
     end
+
+    it 'parses all-caps, hyphenated last names' do
+      name = Name.last_title_first("  HANSON  -  YOUNG  ,   Sarah   Coral")
+      name.first.should == 'Sarah'
+      name.middle.should == 'Coral'
+      name.last.should == 'Hanson-Young'
+    end
   end
 end

--- a/spec/name_spec.rb
+++ b/spec/name_spec.rb
@@ -54,6 +54,34 @@ describe Name do
   end
 
   describe '.last_title_first' do
+    it 'parses names with no middle names' do
+      name = Name.last_title_first("  ALY  ,   Anne  ")
+      name.first.should == 'Anne'
+      name.middle.should == ""
+      name.last.should == 'Aly'
+    end
+
+    it 'parses names with middle names' do
+      name = Name.last_title_first("  BAKER  ,   Mark     Horden  ")
+      name.first.should == 'Mark'
+      name.middle.should == 'Horden'
+      name.last.should == 'Baker'
+    end
+
+    it 'parses names with titles' do
+      name = Name.last_title_first("  BACK  , Dr   Christopher     John  ")
+      name.first.should == 'Christopher'
+      name.middle.should == 'John'
+      name.last.should == 'Back'
+    end
+
+    it 'parses names with titles and brackets' do
+      name = Name.last_title_first("  BAILEY  , the Hon. Frances (  Fran  )   Esther  ")
+      name.first.should == 'Frances'
+      name.middle.should == 'Esther'
+      name.last.should == 'Bailey'
+    end
+
     it 'parses non-hypenated first names' do
       name = Name.last_title_first("  BROWN  ,   Robert   (Bob)   James  ")
       name.first.should == 'Robert'
@@ -68,7 +96,7 @@ describe Name do
       name.last.should == 'Kelly'
     end
 
-    it 'parses all-caps, hyphenated last names' do
+    it 'parses hyphenated last names' do
       name = Name.last_title_first("  HANSON  -  YOUNG  ,   Sarah   Coral")
       name.first.should == 'Sarah'
       name.middle.should == 'Coral'


### PR DESCRIPTION
Sorry this is such a big PR @henare I got a bit carried away trying to understand how it all works :S

See https://github.com/openaustralia/openaustralia/issues/600 for the basic reason why this was happening. In the image downloader, the method needs to get the person’s name of their parlinfo bio page. In then uses this name to select the person it's targeting.

Running `bundle exec member-images.rb` on master produces some incorrect results:

* Pauline Hanson’s image is Sarah Hanson-Young’s image #600
* Sarah Hanson-Young’s image isn't downloaded using her id
* Peter Whish-Wilson’s image isn't downloaded
* Skye Kakoschke-Moore’s image isn't downloaded
* Concetta Anna Fierravanti-Wells’ image isn't downloaded

After these changes, images are downloaded and properly assigned for each of these people. No other images are missing after the changes.

This PR also adds test coverage and a few comments for two of the methods involved in this change.

@henare could you please have a look over this for me? First time contributing to this.

Closes https://github.com/openaustralia/openaustralia/issues/600