### PR TITLE
Added Lucy Gichuhi as new SA Senator

### DIFF
--- a/data/people.csv
+++ b/data/people.csv
@@ -923,3 +923,4 @@ person count,aph id,name,birthday,alt name
 896,265967,Andrew Wallace,,
 897,247512,Kimberley Kitching,,
 898,269583,Peter Georgiou,,
+899,270552,Lucy Gichuhi,,

--- a/data/senators.csv
+++ b/data/senators.csv
@@ -352,3 +352,5 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 866,,Cory Bernardi,,SA,7.2.2017,changed_party,,still_in_office,AC
 867,,Nick Xenophon,,SA,1.7.2016,changed_party,,still_in_office,NXT
 868,,Peter Georgiou,,WA,20.3.2017,,,still_in_office,PHON
+869,,Lucy Gichuhi,,SA,1.7.2016,,26.4.2017,changed_party,FFP
+870,,Lucy Gichuhi,,SA,26.4.2017,,,still_in_office,IND

--- a/data/senators.csv
+++ b/data/senators.csv
@@ -352,5 +352,5 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 866,,Cory Bernardi,,SA,7.2.2017,changed_party,,still_in_office,AC
 867,,Nick Xenophon,,SA,1.7.2016,changed_party,,still_in_office,NXT
 868,,Peter Georgiou,,WA,20.3.2017,,,still_in_office,PHON
-869,,Lucy Gichuhi,,SA,1.7.2016,,26.4.2017,changed_party,FFP
-870,,Lucy Gichuhi,,SA,26.4.2017,,,still_in_office,IND
+869,,Lucy Gichuhi,,SA,19.4.2017,,3.5.2017,changed_party,FFP
+870,,Lucy Gichuhi,,SA,3.5.2017,,,still_in_office,IND

--- a/data/senators.csv
+++ b/data/senators.csv
@@ -352,5 +352,5 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 866,,Cory Bernardi,,SA,7.2.2017,changed_party,,still_in_office,AC
 867,,Nick Xenophon,,SA,1.7.2016,changed_party,,still_in_office,NXT
 868,,Peter Georgiou,,WA,20.3.2017,,,still_in_office,PHON
-869,,Lucy Gichuhi,,SA,19.4.2017,,3.5.2017,changed_party,FFP
+869,,Lucy Gichuhi,,SA,19.4.2017,declared_elected,3.5.2017,changed_party,FFP
 870,,Lucy Gichuhi,,SA,3.5.2017,,,still_in_office,IND


### PR DESCRIPTION
Info for these changes - http://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=270552

In a nut shell:
1) The High Court has declared that Gichuhi's term as a Senator is deemed to have started 1.7.2016 (as a Family First Senator, replacing Bob Day)
2) On 26.4.2017, the FFP merged with Bernardi's Aus Conservatives but Gichuhi has said no to joining and so is now an Independent from that date

These changes feel very odd! I mean, Gichuhi has yet to sit in the Senate but has already clocked up over six months of deemed service and a change in party! But I guess we should follow what her Parliamentary record says...