### PR TITLE
Errors during parsing allow user to patch/retry/continue/quit when --interactive

### DIFF
--- a/create_patch.rb
+++ b/create_patch.rb
@@ -21,7 +21,7 @@ if ARGV.size != 2
   exit
 end
     
-if ARGV[0] == "reps"
+if ARGV[0] == "reps" or ARGV[0] == "representatives"
   house = House.representatives
 elsif ARGV[0] == "senate"
   house = House.senate

--- a/create_patch.rb
+++ b/create_patch.rb
@@ -21,7 +21,7 @@ if ARGV.size != 2
   exit
 end
     
-if ARGV[0] == "reps" or ARGV[0] == "representatives"
+if ARGV[0] == "reps" || ARGV[0] == "representatives"
   house = House.representatives
 elsif ARGV[0] == "senate"
   house = House.senate

--- a/parse-speeches.rb
+++ b/parse-speeches.rb
@@ -97,10 +97,10 @@ def parse_with_retry(interactive, parse, date, path, house)
       choice = STDIN.gets.upcase[0..0]
       if choice == "P"
         system "#{File.dirname(__FILE__)}/create_patch.rb #{house} #{date}"
-        parse_with_retry parse, date, path, house
+        parse_with_retry interactive, parse, date, path, house
         break
       elsif choice == 'R':
-        parse_with_retry parse, date, path, house
+        parse_with_retry interactive, parse, date, path, house
         break
       elsif choice == 'C'
         break

--- a/parse-speeches.rb
+++ b/parse-speeches.rb
@@ -87,11 +87,11 @@ def parse_with_retry(interactive, parse, date, path, house)
     parse.call date, path, house
   rescue Exception => e
     puts "ERROR While processing #{house} #{date}:"
-    puts e.message  
-    puts e.backtrace.join("\n\t")
     if not interactive
       raise
     end
+    puts e.message  
+    puts e.backtrace.join("\n\t")
     while 1
       print "Retry / Patch / Continue / Quit? "
       choice = STDIN.gets.upcase[0..0]

--- a/parse-speeches.rb
+++ b/parse-speeches.rb
@@ -86,6 +86,7 @@ def parse_with_retry(interactive, parse, date, path, house)
   begin
     parse.call date, path, house
   rescue Exception => e
+    puts "ERROR While processing #{house} #{date}:"
     puts e.message  
     puts e.backtrace.join("\n\t")
     if not interactive

--- a/parse-speeches.rb
+++ b/parse-speeches.rb
@@ -87,24 +87,24 @@ def parse_with_retry(interactive, parse, date, path, house)
     parse.call date, path, house
   rescue Exception => e
     puts "ERROR While processing #{house} #{date}:"
-    if not interactive
-      raise
-    end
+    raise unless interactive
+
     puts e.message  
     puts e.backtrace.join("\n\t")
     while 1
       print "Retry / Patch / Continue / Quit? "
       choice = STDIN.gets.upcase[0..0]
-      if choice == "P"
+      case choice
+      when "P"
         system "#{File.dirname(__FILE__)}/create_patch.rb #{house} #{date}"
         parse_with_retry interactive, parse, date, path, house
         break
-      elsif choice == 'R':
+      when "R"
         parse_with_retry interactive, parse, date, path, house
         break
-      elsif choice == 'C'
+      when "C"
         break
-      elsif choice == 'Q'
+      when "Q"
         raise
       end
     end

--- a/parse-speeches.rb
+++ b/parse-speeches.rb
@@ -93,10 +93,13 @@ def parse_with_retry(interactive, parse, date, path, house)
       raise
     end
     while 1
-      print "Patch / Continue / Quit? "
+      print "Retry / Patch / Continue / Quit? "
       choice = STDIN.gets.upcase[0..0]
       if choice == "P"
         system "#{File.dirname(__FILE__)}/create_patch.rb #{house} #{date}"
+        parse_with_retry parse, date, path, house
+        break
+      elsif choice == 'R':
         parse_with_retry parse, date, path, house
         break
       elsif choice == 'C'


### PR DESCRIPTION
This provides a command-line interaction when parsing fails, if using `--interactive`, making it easy to create a patch for the current file. Without this, errors halt the parser, and it's easy to make errors in invoking create-patch.rb manually.