### PR TITLE
Allow patches to accumulate

### DIFF
--- a/create_patch.rb
+++ b/create_patch.rb
@@ -48,4 +48,4 @@ File.open("original.xml", "w") {|f| f << parser.hansard_xml_source_data_on_date(
 FileUtils.cp 'original.xml', 'patched.xml'
 
 system("subl --wait patched.xml")
-system("diff -u original.xml patched.xml > #{patch_file_path}")
+system("diff -u original.xml patched.xml >> #{patch_file_path}")


### PR DESCRIPTION
Unified diffs can be concatenated to apply multiple patches, so patching a patched file and appending the diff is sufficient.