### PR TITLE
Senator Ludlam + Waters resignations

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -259,7 +259,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 255,,Mark Furner,,Queensland,1.7.2008,,30.6.2014,retired,ALP
 256,,Sarah Hanson-Young,,SA,1.7.2008,,,still_in_office,GRN
 257,,Helen Kroger,,Victoria,1.7.2008,,30.6.2014,retired,LIB
-258,,Scott Ludlam,,WA,1.7.2008,,,still_in_office,GRN
+258,,Scott Ludlam,,WA,1.7.2008,,14.7.2017,resigned,GRN
 259,,Louise Pratt,,WA,1.7.2008,,30.6.2014,retired,ALP
 260,,Scott Ryan,,Victoria,1.7.2008,,,still_in_office,LIB
 261,,John Williams,,NSW,1.7.2008,,,still_in_office,NP
@@ -294,7 +294,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 295,,Lisa Singh,,Tasmania,1.7.2011,,,still_in_office,ALP
 296,,Matt Thistlethwaite,,NSW,1.7.2011,,9.8.2013,resigned,ALP
 297,,Anne Urquhart,,Tasmania,1.7.2011,,,still_in_office,ALP
-298,,Larissa Waters,,Queensland,1.7.2011,,,still_in_office,GRN
+298,,Larissa Waters,,Queensland,1.7.2011,,18.7.2017,resigned,GRN
 300,,Penny Wright,,SA,1.7.2011,,10.9.2015,resigned,GRN
 301,,Arthur Sinodinos,,NSW,31.10.2011,section_15,,still_in_office,LIB
 302,,Robert John Carr,,NSW,06.03.2012,,24.10.2013,resigned,ALP


### PR DESCRIPTION
WA Senator Ludlam + QLD Senator Waters have resigned due to citizenship issues. Their replacements aren't decided yet.