### PR TITLE
Senators Nash + Roberts disqualified

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -163,7 +163,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 160,,John Joseph Morris,,NSW,1.7.1985 ,,30.6.1990 ,retired,ALP
 161,,James Anthony Mulvihill,,NSW,1.7.1965 ,,4.2.1983 ,retired,ALP
 162,,Shayne Michael Murphy,,Tas.,1.7.1993 ,,30.6.2005 ,defeated,IND
-164,,Fiona Joy Nash,,NSW,1.7.2005 ,,,still_in_office,NP
+164,,Fiona Joy Nash,,NSW,1.7.2005 ,,27.10.2017,disqualified,NP
 165,,Belinda Jane Neal,,NSW,8.3.1994,section_15,3.9.1998 ,resigned,ALP
 166,,Laurence William Neal,,Vic.,11.3.1980 ,section_15,30.6.1981 ,defeated,NCP
 168,,Jocelyn Margaret Newman,,Tas.,13.3.1986 ,section_15,1.2.2002 ,resigned,LIB
@@ -346,7 +346,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 860,,Skye Kakoschke-Moore,,SA,1.7.2016,,,still_in_office,NXT
 861,,Malarndirri McCarthy,,NT,2.7.2016,,,still_in_office,ALP
 862,,Louise Pratt,,WA,1.7.2016,,,still_in_office,ALP
-863,,Malcolm Roberts,,QLD,1.7.2016,,,still_in_office,PHON
+863,,Malcolm Roberts,,QLD,1.7.2016,,27.10.2017,disqualified,PHON
 864,,Murray Watt,,QLD,1.7.2016,,,still_in_office,ALP
 865,,Kimberley Kitching,,Vic.,25.10.2016,section_15,,still_in_office,ALP
 866,,Cory Bernardi,,SA,7.2.2017,changed_party,,still_in_office,AC


### PR DESCRIPTION
On Fri 27 Oct 2017, the High Court rules Nash & Roberts ineligible thanks to dual citizenship