### PR TITLE
Joyce disqualified

### DIFF
--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -659,7 +659,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 661,,Eric Hutchinson,Lyons,Tas,7.9.2013,,2.7.2016,defeated,LIB
 662,,Andrew Broad,Mallee,Vic,7.9.2013,,,still_in_office,NP
 663,,Ian Goodenough,Moore,WA,7.9.2013,,,still_in_office,LIB
-664,,Barnaby Joyce,New England,NSW,7.9.2013,,,still_in_office,NP
+664,,Barnaby Joyce,New England,NSW,7.9.2013,,27.10.2017,disqualified,NP
 665,,Sharon Claydon,Newcastle,NSW,7.9.2013,,,still_in_office,ALP
 666,,Rick Wilson,O'Connor,WA,7.9.2013,,,still_in_office,LIB
 667,,Kevin Hogan,Page,NSW,7.9.2013,,,still_in_office,NP


### PR DESCRIPTION
On Fri 27 Oct 2017, High Court rules Joyce ineligible due to dual citizenship