### PR TITLE
Dastayari resigned, Anning indep.

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -303,7 +303,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 305,,Peter Stuart Whish-Wilson,,Tas.,20.06.2012,,,still_in_office,GRN
 306,,Anne Ruston,,SA,05.09.2012,section_15,,still_in_office,LIB
 307,,Sue Lines,,WA,15.5.2013,section_15,30.9.2016,changed_party,ALP
-308,,Sam Dastyari,,NSW,21.8.2013,section_15,,still_in_office,ALP
+308,,Sam Dastyari,,NSW,21.8.2013,section_15,25.1.2018,resigned,ALP
 309,,Nova Peris,,NT,07.9.2013,,9.5.2016,retired,ALP
 310,,Mehmet Tillem,,Victoria,21.8.2013,section_15,30.6.2014,retired,ALP
 311,,Zed Seselja,,ACT,07.9.2013,,,still_in_office,LIB
@@ -359,6 +359,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 873,,Slade Brockman,,WA,16.8.2017,section_15,,still_in_office,LIB
 874,,Jordon Steele-John,,WA,10.11.2017,recount,,still_in_office,GRN
 875,,Andrew Bartlett,,Qld,10.11.2017,recount,,still_in_office,GRN
-876,,Fraser Anning,,Qld,10.11.2017,recount,,still_in_office,PHON
+876,,Fraser Anning,,Qld,10.11.2017,recount,15.1.2018,changed_party,PHON
 877,,Scott Ryan,,Victoria,13.11.2017,,,still_in_office,PRES
-888,,Rex Patrick,,SA,14.11.2017,section_15,,still_in_office,NXT
+878,,Rex Patrick,,SA,14.11.2017,section_15,,still_in_office,NXT
+879,,Fraser Anning,,Qld,15.1.2018,changed_party,,still_in_office,IND

--- a/data/senators.csv
+++ b/data/senators.csv
@@ -361,5 +361,8 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 875,,Andrew Bartlett,,Qld,10.11.2017,recount,,still_in_office,GRN
 876,,Fraser Anning,,Qld,10.11.2017,recount,15.1.2018,changed_party,PHON
 877,,Scott Ryan,,Victoria,13.11.2017,,,still_in_office,PRES
-888,,Rex Patrick,,SA,14.11.2017,section_15,,still_in_office,NXT
+# Ordering here has gotten a little out of synch as the choosing of
+# 888 for Rex Patrick was a mistake and we'll just have to fill in the gaps
+# until we get past 888 again and then things will be simpler once more
 879,,Fraser Anning,,Qld,15.1.2018,changed_party,,still_in_office,IND
+888,,Rex Patrick,,SA,14.11.2017,section_15,,still_in_office,NXT

--- a/data/senators.csv
+++ b/data/senators.csv
@@ -361,5 +361,5 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 875,,Andrew Bartlett,,Qld,10.11.2017,recount,,still_in_office,GRN
 876,,Fraser Anning,,Qld,10.11.2017,recount,15.1.2018,changed_party,PHON
 877,,Scott Ryan,,Victoria,13.11.2017,,,still_in_office,PRES
-878,,Rex Patrick,,SA,14.11.2017,section_15,,still_in_office,NXT
+888,,Rex Patrick,,SA,14.11.2017,section_15,,still_in_office,NXT
 879,,Fraser Anning,,Qld,15.1.2018,changed_party,,still_in_office,IND


### PR DESCRIPTION
Sam Dastayari resigned 25.1.2018
Fraser Anning changed to independent 15.1.2018

Also, minor change to number of Rex Patrick - was listed as no. 888 but should be 878 (think this was typo).

There are two other changes coming to our senators (Brandis leaving, Gichuhi going to Libs) but as these changes aren't official on their APH records yet, am leaving them as they are for now.