### PR TITLE
Gallagher leaves + NXT becomes Centre Alliance

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -376,5 +376,3 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 893,,David Smith,,ACT,23.5.2018,,,still_in_office,ALP
 894,,Stirling Griff,,SA,10.4.2018,changed_party,,still_in_office,CA
 895,,Rex Patrick,,SA,10.4.2018,changed_party,,still_in_office,CA
-
-

--- a/data/senators.csv
+++ b/data/senators.csv
@@ -327,7 +327,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 841,,John Madigan,,Victoria,4.9.2014,,9.5.2016,defeated,IND
 842,,Jacqui Lambie,,Tasmania,24.11.2014,,14.11.2017,resigned,IND
 843,,Glenn Lazarus,,QLD,13.3.2015,,9.5.2016,defeated,IND
-844,,Katy Gallagher,,ACT,26.3.2015,,,still_in_office,ALP
+844,,Katy Gallagher,,ACT,26.3.2015,,9.5.2018,disqualified,ALP
 845,,Jenny McAllister,,NSW,6.5.2015,,,still_in_office,ALP
 846,,Jo Lindgren,,QLD,21.5.2015,section_15,9.5.2016,defeated,LIB
 847,,Nick McKim,,Tasmania,19.8.2015,section_15,,still_in_office,GRN
@@ -339,7 +339,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 853,,Anthony Chisholm,,QLD,1.7.2016,,,still_in_office,ALP
 854,,Rod Culleton,,WA,1.7.2016,,11.1.2017,disqualified,PHON
 855,,Don Farrell,,SA,1.7.2016,,,still_in_office,ALP
-856,,Stirling Griff,,SA,1.7.2016,,,still_in_office,NXT
+856,,Stirling Griff,,SA,1.7.2016,,10.4.2018,changed_party,NXT
 857,,Pauline Lee Hanson,,QLD,1.7.2016,,,still_in_office,PHON
 858,,Derryn Hinch,,Victoria,1.7.2016,,,still_in_office,DHJP
 859,,Jane Hume,,Victoria,1.7.2016,,,still_in_office,LIB
@@ -368,9 +368,13 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 879,,Fraser Anning,,Qld,15.1.2018,changed_party,,still_in_office,IND
 880,,Richard Mansell Colbeck,,Tasmania,9.2.2018,high_court,,still_in_office,LIB
 881,,Kristina Keneally,,NSW,14.2.18,section_15,,still_in_office,ALP
-888,,Rex Patrick,,SA,14.11.2017,section_15,,still_in_office,NXT
+888,,Rex Patrick,,SA,14.11.2017,section_15,10.4.2018,changed_party,NXT
 889,,Jim Molan,,NSW,22.12.2017,,,still_in_office,LIB
 890,,Amanda Stoker,,Qld,21.3.2018,section_15,,still_in_office,LIB
 891,,Tim Storer,,SA,16.2.2018,,26.2.2018,changed_party,NXT
 892,,Tim Storer,,SA,26.2.2018,changed_party,,still_in_office,IND
 893,,David Smith,,ACT,23.5.2018,,,still_in_office,ALP
+894,,Stirling Griff,,SA,10.4.2018,changed_party,,still_in_office,CA
+895,,Rex Patrick,,SA,10.4.2018,changed_party,,still_in_office,CA
+
+

--- a/lib/people_csv_reader.rb
+++ b/lib/people_csv_reader.rb
@@ -167,6 +167,8 @@ class PeopleCSVReader
       "Australian Conservatives"
     when "KAP"
       "Katter's Australian Party"
+    when "CA"
+      "Centre Alliance"
     when "ANTI-SOC", "SPK", "CWM", "PRES", "DPRES"
       # Do nothing
       party


### PR DESCRIPTION
Nick Xenophon Party changed name to Centre Alliance 10.4.2018 so I've changed Sen. Griff & Sen. Patrick's records to reflect this.

**Other change made:**
Labor Sen Katy Gallagher's election ruled void under s.44 Const 9.5.2018