### PR TITLE
David Smith enters Senate

### DIFF
--- a/data/people.csv
+++ b/data/people.csv
@@ -802,7 +802,7 @@ person count,aph id,name,birthday,alt name
 765,200287,Penny Wright,,Penelope Lesley Wright
 766,BV7,Arthur Sinodinos,,
 767,WX4,Bob John Carr,,Robert John Carr
-768,241710,Dean Smith,,
+768,241710,Dean Smith,,Dean Anthony Smith
 769,183342,Lin Estelle Thorp,,
 780,195565,Peter Stuart Whish-Wilson,,
 781,243273,Anne Ruston,,
@@ -934,3 +934,4 @@ person count,aph id,name,birthday,alt name
 907,LTU,Ged Kearney,,
 908,237920,Amanda Stoker,,
 909,275424,Tim Storer,,
+910,276714,David Smith,,David Philip Benedict Smith


### PR DESCRIPTION
Have added entry for David Smith (Labor) and added Dean Smith (Liberal)'s full name to his entry so he stops being mixed up with David Smith (due to both being D Smith).

In the week beginning 18 June 2018, they were mixed up due to this issue, so it's vital that both D Smith's have their middle names recorded in our data (Hansard is now listing them as DA Smith and DPB Smith to avoid this issue)