### PR TITLE
David Smith new Labor Senator for ACT

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -373,3 +373,4 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 890,,Amanda Stoker,,Qld,21.3.2018,section_15,,still_in_office,LIB
 891,,Tim Storer,,SA,16.2.2018,,26.2.2018,changed_party,NXT
 892,,Tim Storer,,SA,26.2.2018,changed_party,,still_in_office,IND
+893,,David Smith,,ACT,23.5.2018,,,still_in_office,ALP


### PR DESCRIPTION
Declared elected 23.5.18 (replacing K Gallagher)