### PR TITLE
Sen Lucy Gichuhi now in Liberal Party

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -353,7 +353,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 867,,Nick Xenophon,,SA,1.7.2016,changed_party,6.10.2017,resigned,NXT
 868,,Peter Georgiou,,WA,20.3.2017,,,still_in_office,PHON
 869,,Lucy Gichuhi,,SA,19.4.2017,declared_elected,3.5.2017,changed_party,FFP
-870,,Lucy Gichuhi,,SA,3.5.2017,,,still_in_office,IND
+870,,Lucy Gichuhi,,SA,3.5.2017,changed_party,2.2.2018,changed_party,IND
 871,,Gavin Mark Marshall,,Vic.,9.5.2016,changed_party,,still_in_office,ALP
 872,,Sue Lines,,WA,30.9.2016,changed_party,,still_in_office,DPRES
 873,,Slade Brockman,,WA,16.8.2017,section_15,,still_in_office,LIB
@@ -381,3 +381,5 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 895,,Rex Patrick,,SA,10.4.2018,changed_party,,still_in_office,CA
 896,,Fraser Anning,,Qld,25.10.2018,changed_party,,still_in_office,IND
 897,,Brian Burston,,NSW,18.6.2018,changed_party,,still_in_office,UAP
+898,,Lucy Gichuhi,,SA,2.2.2018,changed_party,,still_in_office,LIB
+


### PR DESCRIPTION
Another change that got away - back on [2 Feb 2018](https://www.abc.net.au/news/2018-02-02/lucy-gichuhi-independent-senator-joins-liberal-party/9392018), Sen Lucy Gichuhi entered the Liberal Party