### PR TITLE
Fudge the data for Sen Brandis resignation

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -23,7 +23,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 22,,Ronald Leslie Doyle Boswell,,Qld,5.3.1983,,30.6.2014,retried,NPA
 23,,Vicki Worrall Bourne,,NSW,1.7.1990,,30.6.2002,defeated,AD
 24,,Suzanne Kay Boyce,,Qld,19.4.2007,section_15,30.6.2014,retired,LIB
-#Brandis resigned on the 7th but was still being listed in pairs until the 15th,,,,,,,,
+#Brandis resigned on the 7th but was still being listed in pairs until the 15th,,,,,,,,,
 25,,George Henry Brandis,,Qld,16.5.2000,section_15,15.2.2018,resigned,LIB
 26,,Carol Louise Brown,,Tas.,25.8.2005,section_15,,still_in_office,ALP
 27,696,Robert James Brown,,Tas.,1.7.1996,,15.06.2012,resigned,GRN


### PR DESCRIPTION
This is required as Hansard still lists him in pairs beyond the date he had resigned. Without this, parser can't tell what to do with these pairs.