### PR TITLE
Senators Bushby and J Collins resign

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -31,7 +31,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 28,,David Gordon Cadell Brownhill,,NSW,1.12.1984,,14.4.2000,resigned,NPA
 29,,Geoffrey Frederick Buckland,,SA,14.9.2000,section_15,30.6.2005,retired,ALP
 30,,Bryant Robert Burns,,Qld,11.7.1987,,30.6.1996,retired,ALP
-31,,David Christopher Bushby,,Tasmania,30.8.2007,section_15,,still_in_office,LIB
+31,,David Christopher Bushby,,Tasmania,30.8.2007,section_15,21.1.2019,resigned,LIB
 32,,John Norman Button,,Vic.,18.5.1974,,31.3.1993,resigned,ALP
 33,,Paul Henry Calvert,,Tas.,11.7.1987,,19.08.2002,changed_party,LIB
 275,,Paul Henry Calvert,,Tas.,19.08.2002,changed_party,14.08.2007,changed_party,PRES
@@ -51,7 +51,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 48,,Ruth Nancy Coleman,,WA,18.5.1974,,5.6.1987,retired,ALP
 49,,Stanley James Collard,,Qld,13.12.1975,,5.6.1987,retired,NPA
 50,,Jacinta Mary Ann Collins,,Vic.,3.5.1995,section_15,30.6.2005,defeated,ALP
-265,,Jacinta Mary Ann Collins,,Vic.,8.5.2008,,,still_in_office,ALP
+265,,Jacinta Mary Ann Collins,,Vic.,8.5.2008,,15.2.2019,resigned,ALP
 51,,Robert Lindsay Collins,,NT,11.7.1987,,30.3.1998,resigned,ALP
 52,,Malcolm Arthur Colston,,Qld,13.12.1975,,30.6.1999,retired,IND
 53,,Stephen Michael Conroy,,Vic.,30.4.1996,section_15,30.9.2016,resigned,ALP


### PR DESCRIPTION
Sen Bushby resigned in January and Sen J Collins resigned this month.

Currently there is no announced replacement for Bushby - media suggests the Liberal Party want to replace him with a female candidate (which makes sense considering all the resignations recently...)

[Media reports](https://www.news.com.au/national/breaking-news/labor-shoppies-still-powerful-senator/news-story/2faa4976e0b995cffe514e864c6efeb0) say Collins will be replaced by Raff Ciccone, but this not yet confirmed

Right now, Parliament running with only 11 senators for Victoria and Tasmania (both should have 12)