### PR TITLE
David Smith resigns

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -377,7 +377,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 890,,Amanda Stoker,,Qld,21.3.2018,section_15,,still_in_office,LIB
 891,,Tim Storer,,SA,16.2.2018,,26.2.2018,changed_party,NXT
 892,,Tim Storer,,SA,26.2.2018,changed_party,,still_in_office,IND
-893,,David Smith,,ACT,23.5.2018,,,still_in_office,ALP
+893,,David Smith,,ACT,23.5.2018,,11.4.2019,resigned,ALP
 894,,Stirling Griff,,SA,10.4.2018,changed_party,,still_in_office,CA
 895,,Rex Patrick,,SA,10.4.2018,changed_party,,still_in_office,CA
 896,,Fraser Anning,,Qld,25.10.2018,changed_party,,still_in_office,IND


### PR DESCRIPTION
ACT Senator David Smith [resigned 11.4.2019](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=276714)