### PR TITLE
Update to Shadow Ministry 2 June 2019

### DIFF
--- a/data/shadow-ministers.csv
+++ b/data/shadow-ministers.csv
@@ -690,108 +690,131 @@
 "Wayne Swan",20/10/1998,01/12/2000,"Shadow Minister for Family and Community Services"
 "Wayne Swan",17/02/2001,25/10/2004,"Shadow Minister for Family and Community Services"
 "Wayne Swan",26/10/2004,06/12/2007,"Shadow Treasurer"
-Bill Shorten MP,13/10/2013,,Leader of the Opposition
-Bill Shorten MP,06/12/2017,,"Shadow Minister for Indigenous Affairs and Aboriginal and Torres Strait Islanders (House)"
-Tanya Plibersek MP,18/10/2013,,Deputy Leader of the Opposition
+Bill Shorten MP,13/10/2013,02/06/2019,Leader of the Opposition
+Bill Shorten MP,06/12/2017,02/06/2019,"Shadow Minister for Indigenous Affairs and Aboriginal and Torres Strait Islanders (House)"
+Hon Bill Shorten MP,02/06/2019,,"Shadow Minister for the National Disability Insurance Scheme"
+Hon Bill Shorten MP,02/06/2019,,"Shadow Minister for Government Services"
+Tanya Plibersek MP,18/10/2013,02/06/2019,Deputy Leader of the Opposition
 Tanya Plibersek MP,18/10/2013,06/12/2017,Shadow Minister for Foreign Affairs and International Development
-Tanya Plibersek MP,06/12/2017,,Shadow Minister for Education and Training
-Tanya Plibersek MP,06/12/2017,,Shadow Minister for Women
-Tanya Plibersek MP,06/12/2017,,"Shadow Minister for Skills, TAFE and Apprenticeships (House)"
-Tanya Plibersek MP,06/12/2017,,Shadow Minister for Foreign Affairs (House)
-Tanya Plibersek MP,06/12/2017,,Shadow Minister for International Development and the Pacific (House)
-Senator Penny Wong,18/10/2013,,Leader of the Opposition in the Senate
+Hon Tanya Plibersek MP,06/12/2017,,Shadow Minister for Education and Training
+Tanya Plibersek MP,06/12/2017,02/06/2019,Shadow Minister for Women
+Tanya Plibersek MP,06/12/2017,02/06/2019,"Shadow Minister for Skills, TAFE and Apprenticeships (House)"
+Tanya Plibersek MP,06/12/2017,02/06/2019,Shadow Minister for Foreign Affairs (House)
+Tanya Plibersek MP,06/12/2017,02/06/2019,Shadow Minister for International Development and the Pacific (House)
+Senator the Hon Penny Wong,18/10/2013,,Leader of the Opposition in the Senate
 Senator Penny Wong,18/10/2013,06/12/2017,Shadow Minister for Trade and Investment
-Senator Penny Wong,06/12/2017,,Shadow Minister for Foreign Affairs
+Senator the Hon Penny Wong,06/12/2017,,Shadow Minister for Foreign Affairs
 Senator Penny Wong,06/12/2017,21/08/2018,Shadow Attorney-General (Senate)
 Senator Penny Wong,06/12/2017,21/08/2018,Shadow Minister for National Security (Senate)
 Senator Penny Wong,06/12/2017,21/08/2018,Shadow Minister for Justice (Senate)
-Senator Penny Wong,21/08/2018,,Shadow Minister for Defence (Senate)
+Senator Penny Wong,21/08/2018,02/06/2019,Shadow Minister for Defence (Senate)
 Senator Stephen Conroy,18/10/2013,06/12/2017,Deputy Leader of the Opposition in the Senate
 Senator Stephen Conroy,18/10/2013,06/12/2017,Shadow Minister for Defence
-Chris Bowen MP,18/10/2013,,Shadow Treasurer
+Chris Bowen MP,18/10/2013,02/06/2019,Shadow Treasurer
 Chris Bowen MP,06/12/2017,21/08/2018,Acting Shadow Minister for Small Business and Financial Services
-Chris Bowen MP,21/08/2018,,Shadow Minister for Small Business
+Chris Bowen MP,21/08/2018,02/06/2019,Shadow Minister for Small Business
+Hon Chris Bowen MP,02/06/2019,,"Shadow Minister for Health"
 Tony Burke MP,18/10/2013,06/12/2017,Shadow Minister for Finance
-Tony Burke MP,18/10/2013,,Manager of Opposition Business (House)
-Tony Burke MP,06/12/2017,,Shadow Minister for Environment and Water
-Tony Burke MP,06/12/2017,,Shadow Minister for Citizenship and Multicultural Australia
-Tony Burke MP,06/12/2017,,Shadow Minister for the Arts
-Mark Dreyfus QC MP,18/10/2013,,Shadow Attorney General
+Tony Burke MP,18/10/2013,02/06/2019,Manager of Opposition Business (House)
+Tony Burke MP,06/12/2017,02/06/2019,Shadow Minister for Environment and Water
+Tony Burke MP,06/12/2017,02/06/2019,Shadow Minister for Citizenship and Multicultural Australia
+Hon Tony Burke MP,06/12/2017,,Shadow Minister for the Arts
+Hon Tony Burke MP,02/06/2019,,"Shadow Minister for Industrial Relations"
+Hon Tony Burke MP,02/06/2019,,"Manager of Opposition Business in the House of Representatives"
+Hon Mark Dreyfus QC MP,18/10/2013,,Shadow Attorney General
 Mark Dreyfus QC MP,18/10/2013,06/12/2017,Shadow Minister for the Arts
-Mark Dreyfus QC MP,18/10/2013,,Deputy Manager of Opposition Business (House)
-Mark Dreyfus QC MP,06/12/2017,,Shadow Minister for National Security
+Mark Dreyfus QC MP,18/10/2013,02/06/2019,Deputy Manager of Opposition Business (House)
+Mark Dreyfus QC MP,06/12/2017,02/06/2019,Shadow Minister for National Security
+Hon Mark Dreyfus QC MP,02/06/2019,,"Shadow Minister for Constitutional Reform"
 Senator Kim Carr,18/10/2013,06/12/2017,Shadow Minister Assisting the Leader for Science
 Senator Kim Carr,18/10/2013,06/12/2017,"Shadow Minister for Higher Education, Research, Innovation and Industry"
-Senator Kim Carr,06/12/2017,,"Shadow Minister for Innovation, Industry, Science and Research"
-Senator Kim Carr,06/12/2017,,Shadow Minister for Trade and Investment (Senate)
-Senator Kim Carr,06/12/2017,,Shadow Minister for Trade in Services (Senate)
-Senator Kim Carr,06/12/2017,,Shadow Minister for Immigration and Border Protection (Senate)
+Senator Kim Carr,06/12/2017,02/06/2019,"Shadow Minister for Innovation, Industry, Science and Research"
+Senator Kim Carr,06/12/2017,02/06/2019,Shadow Minister for Trade and Investment (Senate)
+Senator Kim Carr,06/12/2017,02/06/2019,Shadow Minister for Trade in Services (Senate)
+Senator Kim Carr,06/12/2017,02/06/2019,Shadow Minister for Immigration and Border Protection (Senate)
 Anthony Albanese MP,18/10/2013,06/12/2017,Shadow Minister for Infrastructure and Transport
-Anthony Albanese MP,18/10/2013,,Shadow Minister for Tourism
-Anthony Albanese MP,06/12/2017,,"Shadow Minister for Infrastructure, Transport, Cities and Regional Development"
+Anthony Albanese MP,18/10/2013,02/06/2019,Shadow Minister for Tourism
+Anthony Albanese MP,06/12/2017,02/06/2019,"Shadow Minister for Infrastructure, Transport, Cities and Regional Development"
+Hon Anthony Albanese MP,02/06/2019,,"Leader of the Opposition"
 Mark Butler MP,18/10/2013,06/12/2017,"Shadow Minister for Environment, Climate Change and Water"
-Mark Butler MP,06/12/2017,,Shadow Minister for Climate Change and Energy
+Hon Mark Butler MP,06/12/2017,,Shadow Minister for Climate Change and Energy
+Hon Mark Butler MP,02/06/2019,,"Deputy Manager of Opposition Business in the House of Representatives"
 Jason Clare MP,18/10/2013,06/12/2017,Shadow Minister for Communications
-Jason Clare MP,06/12/2017,,Shadow Minister for Resources and Northern Australia
-Jason Clare MP,06/12/2017,,Shadow Minister for Trade and Investment
+Jason Clare MP,06/12/2017,02/06/2019,Shadow Minister for Resources and Northern Australia
+Jason Clare MP,06/12/2017,02/06/2019,Shadow Minister for Trade and Investment
+Hon Jason Clare MP,02/06/2019,,"Shadow Minister for Regional Services, Territories and Local Government"
+Hon Jason Clare MP,02/06/2019,,"Shadow Minister for Housing and Homelessness"
 Kate Ellis MP,18/10/2013,06/12/2017,Shadow Minister for Education
 Kate Ellis MP,18/10/2013,06/12/2017,Shadow Minister for Early Childhood
 Joel Fitzgibbon MP,18/10/2013,06/12/2017,Shadow Minister for Agriculture
-Joel Fitzgibbon MP,06/12/2017,,"Shadow Minister for Agriculture, Fisheries and Forestry"
-Joel Fitzgibbon MP,06/12/2017,,Shadow Minister for Rural and Regional Australia
+Joel Fitzgibbon MP,06/12/2017,02/06/2019,"Shadow Minister for Agriculture, Fisheries and Forestry"
+Joel Fitzgibbon MP,06/12/2017,02/06/2019,Shadow Minister for Rural and Regional Australia
+Hon Joel Fitzgibbon MP,02/06/2019,,"Shadow Minister for Agriculture and Resources"
 Gary Gray AO MP,18/10/2013,06/12/2017,Shadow Minister for Resources
 Gary Gray AO MP,18/10/2013,06/12/2017,Shadow Minister for Northern Australia
 Gary Gray AO MP,18/10/2013,06/12/2017,Shadow Special Minister of State
 Catherine King MP,18/10/2013,06/12/2017,Shadow Minister for Health
-Catherine King MP,06/12/2017,,Shadow Minister for Health and Medicare
+Catherine King MP,06/12/2017,02/06/2019,Shadow Minister for Health and Medicare
+Hon Catherine King MP,02/06/2019,,"Shadow Minister for Infrastructure, Transport and Regional Development"
 Jenny Macklin MP,18/10/2013,06/12/2017,Shadow Minister for Families and Payments
 Jenny Macklin MP,18/10/2013,06/12/2017,Shadow Minister for Disability Reform
 Jenny Macklin MP,06/12/2017,21/08/2018,Shadow Minister for Disability and Carers (House)
 Jenny Macklin MP,06/12/2017,21/08/2018,Shadow Minister for Families and Social Services
 Jenny Macklin MP,06/12/2017,21/08/2018,Shadow Minister for Housing and Homelessness
 Richard Marles MP,18/10/2013,06/12/2017,Shadow Minister for Immigration and Border Protection
-Richard Marles MP,06/12/2017,,Shadow Minister for Defence
+Hon Richard Marles MP,06/12/2017,,Shadow Minister for Defence
+Hon Richard Marles MP,02/06/2019,,"Deputy Leader of the Opposition"
 Shayne Neumann MP,18/10/2013,06/12/2017,Shadow Minister for Indigenous Affairs
 Shayne Neumann MP,18/10/2013,06/12/2017,Shadow Minister for Ageing
-Shayne Neumann MP,06/12/2017,,Shadow Minister for Immigration and Border Protection
-Brendan O’Connor MP,18/10/2013,,Shadow Minister for Employment and Workplace Relations
+Shayne Neumann MP,06/12/2017,02/06/2019,Shadow Minister for Immigration and Border Protection
+Hon Shayne Neumann MP,02/06/2019,,"Shadow Minister for Veterans' Affairs and Defence Personnel"
+Brendan O’Connor MP,18/10/2013,02/06/2019,Shadow Minister for Employment and Workplace Relations
+Hon Brendan O’Connor MP,02/06/2019,,"Shadow Minister for Employment and Industry"
+Hon Brendan O’Connor MP,02/06/2019,,"Shadow Minister for Science"
+Hon Brendan O’Connor MP,02/06/2019,,"Shadow Minister for Small and Family Business"
 Bernie Ripoll MP,18/10/2013,06/12/2017,Shadow Minister Assisting the Leader for Small Business
 Bernie Ripoll MP,18/10/2013,06/12/2017,Shadow Minister for Financial Services and Superannuation
 Bernie Ripoll MP,18/10/2013,06/12/2017,Shadow Minister for Sport
-Senator Claire Moore,18/10/2013,,Shadow Minister for Women
+Senator Claire Moore,18/10/2013,02/06/2019,Shadow Minister for Women
 Senator Claire Moore,18/10/2013,06/12/2017,Manager of Opposition Business (Senate)
 Senator Claire Moore,18/10/2013,06/12/2017,Shadow Minister for Carers
 Senator Claire Moore,18/10/2013,06/12/2017,Shadow Minister for Communities
-Senator Claire Moore,06/12/2017,,Shadow Minister for International Development and the Pacific
+Senator Claire Moore,06/12/2017,02/06/2019,Shadow Minister for International Development and the Pacific
 Senator Claire Moore,06/12/2017,21/08/2018,Shadow Minister for Climate Change and Energy (Senate)
-Senator Claire Moore,06/12/2017,,Shadow Minister for Resources and Northern Australia (Senate)
-Senator Claire Moore,06/12/2017,,Shadow Minister Assisting for Resources (Senate)
-Senator Claire Moore,21/08/2018,,Shadow Minister for Preventing Family Violence (Senate)
+Senator Claire Moore,06/12/2017,02/06/2019,Shadow Minister for Resources and Northern Australia (Senate)
+Senator Claire Moore,06/12/2017,02/06/2019,Shadow Minister Assisting for Resources (Senate)
+Senator Claire Moore,21/08/2018,02/06/2019,Shadow Minister for Preventing Family Violence (Senate)
 Senator Don Farrell,18/10/2013,06/12/2017,Shadow Minister for the Centenary of ANZAC
 Senator Don Farrell,18/10/2013,06/12/2017,Shadow Minister for Veterans’ Affairs
-Senator Don Farrell,06/12/2017,,Deputy Leader of the Opposition in the Senate
-Senator Don Farrell,06/12/2017,,Shadow Special Minister of State
-Senator Don Farrell,06/12/2017,,Shadow Minister for Sport
+Senator Don Farrell,06/12/2017,02/06/2019,Deputy Leader of the Opposition in the Senate
+Senator the Hon Don Farrell,06/12/2017,,Shadow Special Minister of State
+Senator the Hon Don Farrell,06/12/2017,,Shadow Minister for Sport
 Senator Don Farrell,06/12/2017,21/08/2018,"Shadow Minister for Infrastructure, Transport, Cities and Regional Development (Senate)"
 Senator Don Farrell,06/12/2017,21/08/2018,"Shadow Minister for Regional Services, Territories and Local Government (Senate)"
 Senator Don Farrell,06/12/2017,21/08/2018,Shadow Minister for Defence (Senate)
-Senator Don Farrell,06/12/2017,,Shadow Minister for Veterans' Affairs (Senate)
-Senator Don Farrell,06/12/2017,,Shadow Minister for Defence Personnel (Senate)
-Senator Don Farrell,06/12/2017,,Shadow Minister for Finance (Senate)
-Senator Don Farrell,21/08/2018,,Shadow Attorney-General (Senate)
-Senator Don Farrell,21/08/2018,,Shadow Minister for National Security (Senate)
-Senator Don Farrell,21/08/2018,,Shadow Minister for Justice (Senate)
+Senator Don Farrell,06/12/2017,02/06/2019,Shadow Minister for Veterans' Affairs (Senate)
+Senator Don Farrell,06/12/2017,02/06/2019,Shadow Minister for Defence Personnel (Senate)
+Senator Don Farrell,06/12/2017,02/06/2019,Shadow Minister for Finance (Senate)
+Senator Don Farrell,21/08/2018,02/06/2019,Shadow Attorney-General (Senate)
+Senator Don Farrell,21/08/2018,02/06/2019,Shadow Minister for National Security (Senate)
+Senator Don Farrell,21/08/2018,02/06/2019,Shadow Minister for Justice (Senate)
+Senator the Hon Don Farrell,02/06/2019,,"Shadow Minister for Tourism"
+Senator the Hon Don Farrell,02/06/2019,,"Shadow Minister Assisting the Leader of the Opposition"
 David Feeney MP,18/10/2013,06/12/2017,Shadow Minister for Justice
 David Feeney MP,18/10/2013,06/12/2017,Shadow Assistant Minister for Defence
 Julie Collins MP,18/10/2013,06/12/2017,Shadow Minister for Regional Development and Local Government
 Julie Collins MP,18/10/2013,06/12/2017,Shadow Minister for Employment Services
-Julie Collins MP,06/12/2017,,Shadow Minister for Ageing and Mental Health
-Dr Andrew Leigh MP,18/10/2013,,Shadow Assistant Treasurer
+Julie Collins MP,06/12/2017,02/06/2019,Shadow Minister for Ageing and Mental Health
+Hon Julie Collins MP,02/06/2019,,"Shadow Minister for Ageing and Seniors"
+Hon Julie Collins MP,02/06/2019,,"Shadow Minister for Women"
+Dr Andrew Leigh MP,18/10/2013,02/06/2019,Shadow Assistant Treasurer
 Dr Andrew Leigh MP,18/10/2013,06/12/2017,Shadow Minister for Competition
-Dr Andrew Leigh MP,06/12/2017,,Shadow Minister for Competition and Productivity
-Dr Andrew Leigh MP,06/12/2017,,Shadow Minister for Charities and Not-for-Profits
-Dr Andrew Leigh MP,06/12/2017,,"Shadow Minister for Innovation, Industry, Science and Research (House)"
-Dr Andrew Leigh MP,06/12/2017,,Shadow Minister for Trade in Services
+Dr Andrew Leigh MP,06/12/2017,02/06/2019,Shadow Minister for Competition and Productivity
+Dr Andrew Leigh MP,06/12/2017,02/06/2019,Shadow Minister for Charities and Not-for-Profits
+Dr Andrew Leigh MP,06/12/2017,02/06/2019,"Shadow Minister for Innovation, Industry, Science and Research (House)"
+Dr Andrew Leigh MP,06/12/2017,02/06/2019,Shadow Minister for Trade in Services
+Hon Dr Andrew Leigh MP,02/06/2019,,"Shadow Assistant Minister for Treasury"
+Hon Dr Andrew Leigh MP,02/06/2019,,"Shadow Assistant Minister for Charities"
 Sharon Bird MP,18/10/2013,06/12/2017,Shadow Minister for Vocational Education
 Michelle Rowland MP,18/10/2013,06/12/2017,Shadow Assistant Minister for Communications
 Michelle Rowland MP,18/10/2013,06/12/2017,Shadow Minister for Citizenship and Multiculturalism
@@ -799,24 +822,24 @@ Michelle Rowland MP,06/12/2017,,Shadow Minister for Communications
 Melissa Parke MP,18/10/2013,06/12/2017,Shadow Assistant Minister for Health
 Senator Jan McLucas,18/10/2013,06/12/2017,Shadow Minister for Mental Health
 Senator Jan McLucas,18/10/2013,06/12/2017,Shadow Minister for Housing and Homelessness
-Senator Doug Cameron,18/10/2013,,Shadow Minister for Human Services
-Senator Doug Cameron,06/12/2017,,"Shadow Minister for Skills, TAFE and Apprenticeships"
-Senator Doug Cameron,06/12/2017,,Shadow Treasurer (Senate)
-Senator Doug Cameron,06/12/2017,,Shadow Assistant Treasurer (Senate)
-Senator Doug Cameron,06/12/2017,,Shadow Minister for Competition and Productivity (Senate)
-Senator Doug Cameron,06/12/2017,,Shadow Minister for Charities and Not-for-profits (Senate)
-Senator Doug Cameron,06/12/2017,,Shadow Minister for the Digital Economy (Senate)
+Senator Doug Cameron,18/10/2013,02/06/2019,Shadow Minister for Human Services
+Senator Doug Cameron,06/12/2017,02/06/2019,"Shadow Minister for Skills, TAFE and Apprenticeships"
+Senator Doug Cameron,06/12/2017,02/06/2019,Shadow Treasurer (Senate)
+Senator Doug Cameron,06/12/2017,02/06/2019,Shadow Assistant Treasurer (Senate)
+Senator Doug Cameron,06/12/2017,02/06/2019,Shadow Minister for Competition and Productivity (Senate)
+Senator Doug Cameron,06/12/2017,02/06/2019,Shadow Minister for Charities and Not-for-profits (Senate)
+Senator Doug Cameron,06/12/2017,02/06/2019,Shadow Minister for the Digital Economy (Senate)
 Senator Doug Cameron,06/12/2017,21/08/2018,Shadow Minister for Consumer Affairs (Senate)
-Senator Doug Cameron,06/12/2017,,Shadow Minister for Housing and Homelessness
-Senator Doug Cameron,06/12/2017,,Shadow Minister for Families and Social Services (Senate)
-Senator Doug Cameron,06/12/2017,,Shadow Minister for Employment and Workplace Relations (Senate)
-Senator Doug Cameron,06/12/2017,,"Shadow Minister for Employment Services, Workforce Participation and Future of Work (Senate)"
+Senator Doug Cameron,06/12/2017,02/06/2019,Shadow Minister for Housing and Homelessness
+Senator Doug Cameron,06/12/2017,02/06/2019,Shadow Minister for Families and Social Services (Senate)
+Senator Doug Cameron,06/12/2017,02/06/2019,Shadow Minister for Employment and Workplace Relations (Senate)
+Senator Doug Cameron,06/12/2017,02/06/2019,"Shadow Minister for Employment Services, Workforce Participation and Future of Work (Senate)"
 Senator Doug Cameron,06/12/2017,21/08/2018,Acting Shadow Minister for Small Business and Financial Services (Senate)
-Senator Doug Cameron,21/08/2018,,Shadow Minister for Small Business (Senate)
+Senator Doug Cameron,21/08/2018,02/06/2019,Shadow Minister for Small Business (Senate)
 Julie Owens MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Small Business
 Julie Owens MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Education
-Julie Owens MP,06/12/2017,,Shadow Assistant Minister for Citizenship and Multicultural Australia
-Julie Owens MP,06/12/2017,,Shadow Assistant Minister for Small Business
+Julie Owens MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Citizenship and Multicultural Australia
+Julie Owens MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Small Business
 Senator Jacinta Collins,18/10/2013,18/02/2019,Shadow Cabinet Secretary
 Senator Jacinta Collins,18/10/2013,21/08/2018,Shadow Parliamentary Secretary to the Leader of the Opposition
 Senator Jacinta Collins,06/12/2017,18/02/2019,Shadow Minister for Education and Training (Senate)
@@ -830,93 +853,140 @@ Michael Danby MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary to the Lea
 Michael Danby MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for the Arts
 Dr Jim Chalmers MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary to the Leader of the Opposition
 Dr Jim Chalmers MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Trade and Investment
-Dr Jim Chalmers MP,06/12/2017,,Shadow Special Minister of State (House)
-Dr Jim Chalmers MP,06/12/2017,,Shadow Minister for Sport (House)
-Dr Jim Chalmers MP,06/12/2017,,Shadow Minister for Finance
+Dr Jim Chalmers MP,06/12/2017,02/06/2019,Shadow Special Minister of State (House)
+Dr Jim Chalmers MP,06/12/2017,02/06/2019,Shadow Minister for Sport (House)
+Dr Jim Chalmers MP,06/12/2017,02/06/2019,Shadow Minister for Finance
+Dr Jim Chalmers MP,02/06/2019,,Shadow Treasurer
 Matt Thistlethwaite MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Foreign Affairs
 Matt Thistlethwaite MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Immigration
-Matt Thistlethwaite MP,06/12/2017,,Shadow Assistant Minister for Treasury
-Matt Thistlethwaite MP,06/12/2017,,Shadow Assistant Minister for an Australian Head of State
+Matt Thistlethwaite MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Treasury
+Matt Thistlethwaite MP,06/12/2017,02/06/2019,Shadow Assistant Minister for an Australian Head of State
+Hon Matt Thistlethwaite MP,02/06/2019,,"Shadow Assistant Minister for Financial Services"
+Hon Matt Thistlethwaite MP,02/06/2019,,"Shadow Assistant Minister for the Republic"
 Gai Brodtmann MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Defence
-Gai Brodtmann MP,06/12/2017,,Shadow Assistant Minister for Cyber Security and Defence
+Gai Brodtmann MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Cyber Security and Defence
 Stephen Jones MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Regional Development and Infrastructure
-Stephen Jones MP,06/12/2017,,"Shadow Minister for Regional Services, Territories and Local Government"
-Stephen Jones MP,06/12/2017,,Shadow Minister for Regional Communications
+Stephen Jones MP,06/12/2017,02/06/2019,"Shadow Minister for Regional Services, Territories and Local Government"
+Stephen Jones MP,06/12/2017,02/06/2019,Shadow Minister for Regional Communications
+Stephen Jones MP,02/06/2019,,"Shadow Assistant Treasurer"
+Stephen Jones MP,02/06/2019,,"Shadow Minister for Financial Services"
 Warren Snowdon MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for External Territories
 Warren Snowdon MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Northern Australia
 Warren Snowdon MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Indigenous Affairs
-Warren Snowdon MP,06/12/2017,,Shadow Assistant Minister for External Territories
-Warren Snowdon MP,06/12/2017,,Shadow Assistant Minister for the Centenary of ANZAC
-Warren Snowdon MP,06/12/2017,,Shadow Assistant Minister for Indigenous Health
-Warren Snowdon MP,06/12/2017,,Shadow Assistant Minister for Northern Australia
+Hon Warren Snowdon MP,06/12/2017,,Shadow Assistant Minister for External Territories
+Warren Snowdon MP,06/12/2017,02/06/2019,Shadow Assistant Minister for the Centenary of ANZAC
+Warren Snowdon MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Indigenous Health
+Hon Warren Snowdon MP,06/12/2017,,Shadow Assistant Minister for Northern Australia
+Hon Warren Snowdon MP,02/06/2019,,"Shadow Assistant Minister for Indigenous Australians"
 Ed Husic MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary to the Shadow Treasurer
-Ed Husic MP,06/12/2017,,Shadow Minister for the Digital Economy
+Ed Husic MP,06/12/2017,02/06/2019,Shadow Minister for the Digital Economy
 Ed Husic MP,06/12/2017,21/08/2018,"Shadow Minister for Employment Services, Workforce Participation and Future of Work"
-Ed Husic MP,21/08/2018,,Shadow Minister for Human Services
+Ed Husic MP,21/08/2018,02/06/2019,Shadow Minister for Human Services
 Senator Louise Pratt,18/10/2013,06/12/2017,"Shadow Parliamentary Secretary for the Environment, Climate Change and Water"
-Senator Louise Pratt,06/12/2017,,Shadow Minister for Environment and Water (Senate)
+Senator Louise Pratt,06/12/2017,02/06/2019,Shadow Minister for Environment and Water (Senate)
 Senator Louise Pratt,06/12/2017,21/08/2018,Shadow Assistant Minister for Families and Communities
-Senator Louise Pratt,21/08/2018,,Shadow Minister for Young Australians and Youth Affairs (Senate)
-Senator Louise Pratt,21/08/2018,,Shadow Assistant Minister for Universities
-Senator Louise Pratt,21/08/2018,,Shadow Assistant Minister for Equality
-Senator Louise Pratt,18/02/2019,,Shadow Minister for Citizenship and Multicultural Australia (Senate)
-Senator Louise Pratt,18/02/2019,,Shadow Minister for the Arts (Senate)
+Senator Louise Pratt,21/08/2018,02/06/2019,Shadow Minister for Young Australians and Youth Affairs (Senate)
+Senator Louise Pratt,21/08/2018,02/06/2019,Shadow Assistant Minister for Universities
+Senator Louise Pratt,21/08/2018,02/06/2019,Shadow Assistant Minister for Equality
+Senator Louise Pratt,18/02/2019,02/06/2019,Shadow Minister for Citizenship and Multicultural Australia (Senate)
+Senator Louise Pratt,18/02/2019,02/06/2019,Shadow Minister for the Arts (Senate)
+Senator Louise Pratt,02/06/2019,,"Shadow Assistant Minister for Manufacturing"
 Tony Zappia MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Manufacturing
-Tony Zappia MP,06/12/2017,,Shadow Assistant Minister for Medicare
+Tony Zappia MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Medicare
 Senator Lisa Singh,18/10/2013,06/12/2017,Shadow Parliamentary Secretary to the Shadow Attorney General
 Amanda Rishworth MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Health
-Amanda Rishworth MP,06/12/2017,,Shadow Minister for Veterans' Affairs
-Amanda Rishworth MP,06/12/2017,,Shadow Minister for Defence Personnel
-Amanda Rishworth MP,06/12/2017,,Shadow Minister for Early Childhood Education and Development
+Amanda Rishworth MP,06/12/2017,02/06/2019,Shadow Minister for Veterans' Affairs
+Amanda Rishworth MP,06/12/2017,02/06/2019,Shadow Minister for Defence Personnel
+Amanda Rishworth MP,06/12/2017,02/06/2019,Shadow Minister for Early Childhood Education and Development
+Hon Amanda Rishworth MP,02/06/2019,,"Shadow Minister for Early Childhood Education"
+Hon Amanda Rishworth MP,02/06/2019,,"Shadow Minister for Youth"
 Senator Carol Brown,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Families and Payments
-Senator Carol Brown,06/12/2017,,Shadow Minister for Disability and Carers
-Senator Carol Brown,06/12/2017,,Shadow Minister for Tourism (Senate)
-Senator Carol Brown,06/12/2017,,"Shadow Minister for Agriculture, Fisheries and Forestry (Senate)"
-Senator Carol Brown,06/12/2017,,Shadow Minister for Rural and Regional Australia (Senate)
+Senator Carol Brown,06/12/2017,02/06/2019,Shadow Minister for Disability and Carers
+Senator Carol Brown,06/12/2017,02/06/2019,Shadow Minister for Tourism (Senate)
+Senator Carol Brown,06/12/2017,02/06/2019,"Shadow Minister for Agriculture, Fisheries and Forestry (Senate)"
+Senator Carol Brown,06/12/2017,02/06/2019,Shadow Minister for Rural and Regional Australia (Senate)
+Senator Carol Brown,02/06/2019,,"Shadow Assistant Minister for Infrastructure and Regional Tourism"
+Senator Carol Brown,02/06/2019,,"Shadow Assistant Minister for Tasmania"
 Senator Helen Polley,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Aged Care
-Senator Helen Polley,06/12/2017,,"Shadow Assistant Minister to the Leader (Tasmania)"
-Senator Helen Polley,06/12/2017,,Shadow Minister for Health and Medicare (Senate)
-Senator Helen Polley,06/12/2017,,Shadow Minister for Ageing and Mental Health (Ageing)
-Senator Helen Polley,06/12/2017,,Shadow Assistant Minister for Ageing
-Senator Patrick Dodson,06/12/2017,,"Shadow Minister for Indigenous Affairs and Aboriginal and Torres Strait Islanders (Senate)"
-Senator Patrick Dodson,06/12/2017,,"Shadow Assistant Minister for Indigenous Affairs and Aboriginal and Torres Strait Islanders"
-Senator Patrick Dodson,06/12/2017,,Shadow Minister for Regional Communications (Senate)
+Senator Helen Polley,06/12/2017,02/06/2019,"Shadow Assistant Minister to the Leader (Tasmania)"
+Senator Helen Polley,06/12/2017,02/06/2019,Shadow Minister for Health and Medicare (Senate)
+Senator Helen Polley,06/12/2017,02/06/2019,Shadow Minister for Ageing and Mental Health (Ageing)
+Senator Helen Polley,06/12/2017,02/06/2019,Shadow Assistant Minister for Ageing
+Senator Patrick Dodson,06/12/2017,02/06/2019,"Shadow Minister for Indigenous Affairs and Aboriginal and Torres Strait Islanders (Senate)"
+Senator Patrick Dodson,06/12/2017,02/06/2019,"Shadow Assistant Minister for Indigenous Affairs and Aboriginal and Torres Strait Islanders"
+Senator Patrick Dodson,06/12/2017,02/06/2019,Shadow Minister for Regional Communications (Senate)
+Senator Patrick Dodson,02/06/2019,,"Shadow Assistant Minister for Reconciliation"
+Senator Patrick Dodson,02/06/2019,,"Shadow Assistant Minister for Constitutional Recognition of Indigenous Australians"
 Terri Butler MP,06/12/2017,21/08/2018,"Shadow Assistant Minister for Preventing Family Violence"
 Terri Butler MP,06/12/2017,21/08/2018,"Shadow Assistant Minister for Universities"
 Terri Butler MP,06/12/2017,21/08/2018,"Shadow Assistant Minister for Equality"
-Terri Butler MP,21/08/2018,,Shadow Minister for Young Australians and Youth Affairs
-Terri Butler MP,21/08/2018,,"Shadow Minister for Employment Services, Workforce Participation and Future of Work"
-Andrew Giles MP,06/12/2017,,"Shadow Assistant Minister for Schools"
+Terri Butler MP,21/08/2018,02/06/2019,Shadow Minister for Young Australians and Youth Affairs
+Terri Butler MP,21/08/2018,02/06/2019,"Shadow Minister for Employment Services, Workforce Participation and Future of Work"
+Terri Butler MP,02/06/2019,,"Shadow Minister for the Environment and Water"
+Andrew Giles MP,06/12/2017,02/06/2019,"Shadow Assistant Minister for Schools"
+Andrew Giles MP,02/06/2019,,"Shadow Minister for Cities and Urban Infrastructure"
+Andrew Giles MP,02/06/2019,,"Shadow Minister for Multicultural Affairs"
+Andrew Giles MP,02/06/2019,,"Shadow Minister Assisting for Immigration and Citizenship"
 Tim Hammond MP,06/12/2017,21/08/2018,Shadow Minister for Consumer Affairs
 Tim Hammond MP,06/12/2017,21/08/2018,Shadow Minister Assisting for Resources
 Linda Burney MP,06/12/2017,21/08/2018,Shadow Minister for Human Services
-Linda Burney MP,21/08/2018,,Shadow Minister for Preventing Family Violence
-Linda Burney MP,21/08/2018,,Shadow Minister for Families and Social Services
-Linda Burney MP,21/08/2018,,Shadow Minister for Housing and Homelessness (House)
-Linda Burney MP,21/08/2018,,Shadow Minister for Disability and Carers (House)
-Pat Conroy MP,06/12/2017,,Shadow Assistant Minister for Infrastructure
-Pat Conroy MP,06/12/2017,,Shadow Assistant Minister for Climate Change and Energy
-Clare O'Neil MP,06/12/2017,,Shadow Minister for Justice
-Clare O'Neil MP,21/08/2018,,Shadow Minister for Financial Services
-Lisa Chesters MP,06/12/2017,,Shadow Assistant Minister for Workplace Relations
-Lisa Chesters MP,06/12/2017,,Shadow Assistant Minister for Rural and Regional Australia
-Mike Kelly AM MP,06/12/2017,,Shadow Assistant Minister for Defence Industry and Support
-Nick Champion MP,06/12/2017,,Shadow Assistant Minister for Manufacturing and Science
-Senator Deborah O'Neill,06/12/2017,,Shadow Assistant Minister for Innovation
-Senator Deborah O'Neill,06/12/2017,,Shadow Minister for Communications (Senate)
-Senator Deborah O'Neill,06/12/2017,,Shadow Minister for Ageing and Mental Health (Mental Health)
-Senator Deborah O'Neill,06/12/2017,,Shadow Assistant Minister for Mental Health
-Senator Deborah O'Neill,21/08/2018,,Shadow Minister for Financial Services (Senate)
-Senator Deborah O'Neill,21/08/2018,,Shadow Minister for Consumer Affairs (Senate)
-Senator Deborah O'Neill,21/08/2018,,Shadow Minister Assisting for Small Business (Senate)
-Senator Deborah O'Neill,18/02/2019,,Shadow Minister for Education and Training (Senate)
-Senator Deborah O'Neill,18/02/2019,,Manager of Opposition Business in the Senate
-Senator Deborah O'Neill,18/02/2019,,Shadow Minister for Early Childhood Education and Development (Senate)
-Madeleine King MP,21/08/2018,,Shadow Minister for Consumer Affairs
-Madeleine King MP,21/08/2018,,Shadow Minister Assisting for Small Business
-Madeleine King MP,21/08/2018,,Shadow Minister Assisting for Resources
-Senator Jenny McAllister,21/08/2018,,Shadow Assistant Minister for Families and Communities
-Senator Jenny McAllister,21/08/2018,,Shadow Minister for Climate Change and Energy
-Senator Glenn Sterle,21/08/2018,,"Shadow Minister for Infrastructure, Transport, Cities and Regional Development (Senate)"
-Senator Glenn Sterle,21/08/2018,,"Shadow Minister for Regional Services, Territories and Local Government (Senate)"
+Linda Burney MP,21/08/2018,02/06/2019,Shadow Minister for Preventing Family Violence
+Hon Linda Burney MP,21/08/2018,,Shadow Minister for Families and Social Services
+Linda Burney MP,21/08/2018,02/06/2019,Shadow Minister for Housing and Homelessness (House)
+Linda Burney MP,21/08/2018,02/06/2019,Shadow Minister for Disability and Carers (House)
+Hon Linda Burney MP,02/06/2019,,"Shadow Minister for Indigenous Australians"
+Pat Conroy MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Infrastructure
+Pat Conroy MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Climate Change and Energy
+Pat Conroy MP,02/06/2019,,"Shadow Minister for International Development and the Pacific"
+Pat Conroy MP,02/06/2019,,"Shadow Minister Assisting for Climate Change"
+Pat Conroy MP,02/06/2019,,"Shadow Minister Assisting for Defence"
+Clare O'Neil MP,06/12/2017,02/06/2019,Shadow Minister for Justice
+Clare O'Neil MP,21/08/2018,02/06/2019,Shadow Minister for Financial Services
+Clare O'Neil MP,02/06/2019,,"Shadow Minister for Innovation, Technology and the Future of Work"
+Lisa Chesters MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Workplace Relations
+Lisa Chesters MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Rural and Regional Australia
+Mike Kelly AM MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Defence Industry and Support
+Hon Dr Mike Kelly AM MP,02/06/2019,,"Shadow Assistant Minister for Defence"
+Nick Champion MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Manufacturing and Science
+Senator Deborah O'Neill,06/12/2017,02/06/2019,Shadow Assistant Minister for Innovation
+Senator Deborah O'Neill,06/12/2017,02/06/2019,Shadow Minister for Communications (Senate)
+Senator Deborah O'Neill,06/12/2017,02/06/2019,Shadow Minister for Ageing and Mental Health (Mental Health)
+Senator Deborah O'Neill,06/12/2017,02/06/2019,Shadow Assistant Minister for Mental Health
+Senator Deborah O'Neill,21/08/2018,02/06/2019,Shadow Minister for Financial Services (Senate)
+Senator Deborah O'Neill,21/08/2018,02/06/2019,Shadow Minister for Consumer Affairs (Senate)
+Senator Deborah O'Neill,21/08/2018,02/06/2019,Shadow Minister Assisting for Small Business (Senate)
+Senator Deborah O'Neill,18/02/2019,02/06/2019,Shadow Minister for Education and Training (Senate)
+Senator Deborah O'Neill,18/02/2019,02/06/2019,Manager of Opposition Business in the Senate
+Senator Deborah O'Neill,18/02/2019,02/06/2019,Shadow Minister for Early Childhood Education and Development (Senate)
+Madeleine King MP,21/08/2018,02/06/2019,Shadow Minister for Consumer Affairs
+Madeleine King MP,21/08/2018,02/06/2019,Shadow Minister Assisting for Small Business
+Madeleine King MP,21/08/2018,02/06/2019,Shadow Minister Assisting for Resources
+Madeleine King MP,02/06/2019,,"Shadow Minister for Trade"
+Senator Jenny McAllister,21/08/2018,02/06/2019,Shadow Assistant Minister for Families and Communities
+Senator Jenny McAllister,21/08/2018,02/06/2019,Shadow Minister for Climate Change and Energy
+Senator Jenny McAllister,02/06/2019,,"Shadow Cabinet Secretary"
+Senator Jenny McAllister,02/06/2019,,"Shadow Assistant Minister to the Leader of the Opposition in the Senate"
+Senator Glenn Sterle,21/08/2018,02/06/2019,"Shadow Minister for Infrastructure, Transport, Cities and Regional Development (Senate)"
+Senator Glenn Sterle,21/08/2018,02/06/2019,"Shadow Minister for Regional Services, Territories and Local Government (Senate)"
 Senator Glenn Sterle,21/08/2018,,Shadow Assistant Minister for Road Safety
+Senator the HonKristina Keneally,02/06/2019,,"Deputy Leader of the Opposition in the Senate"
+Senator the Hon Kristina Keneally,02/06/2019,,"Shadow Minister for Home Affairs"
+Senator the Hon Kristina Keneally,02/06/2019,,"Shadow Minister for Immigration and Citizenship"
+Senator Katy Gallagher,02/06/2019,,"Shadow Minister for Finance"
+Senator Katy Gallagher,02/06/2019,,"Shadow Minister for the Public Service"
+Senator Katy Gallagher,02/06/2019,,"Manager of Opposition Business in the Senate"
+Matt Keogh MP,02/06/2019,,"Shadow Minister for Defence Industry"
+Matt Keogh MP,02/06/2019,,"Shadow Minister for Western Australian Resources"
+Matt Keogh MP,02/06/2019,,"Shadow Minister Assisting for Small and Family Business"
+Senator Murray Watt,02/06/2019,,"Shadow Minister for Northern Australia"
+Senator Murray Watt,02/06/2019,,"Shadow Minister for Natural Disaster and Emergency Management"
+Graham Perrett MP,02/06/2019,,"Shadow Assistant Minister for Education and Training"
+Emma McBride MP,02/06/2019,,"Shadow Assistant Minister for Mental Health"
+Emma McBride MP,02/06/2019,,"Shadow Assistant Minister for Carers"
+Ged Kearney MP,02/06/2019,,"Shadow Assistant Minister for Skills"
+Ged Kearney MP,02/06/2019,,"Shadow Assistant Minister for Aged Care"
+Josh Wilson MP,02/06/2019,,"Shadow Assistant Minister for the Environment"
+Senator Kimberley Kitching,02/06/2019,,"Shadow Assistant Minister for Government Accountability"
+Senator Kimberley Kitching,02/06/2019,,"Deputy Manager of Opposition Business in the Senate"
+Tim Watts MP,02/06/2019,,"Shadow Assistant Minister for Communications"
+Tim Watts MP,02/06/2019,,"Shadow Assistant Minister for Cyber Security"

--- a/data/shadow-ministers.csv
+++ b/data/shadow-ministers.csv
@@ -154,8 +154,8 @@
 "Greg Hunt",08/12/2009,18/09/2013,"Shadow Minister for Climate Action, Environment and Heritage"
 "Greg Hunt",06/12/2007,22/09/2008,"Shadow Minister for Climate Change, Environment and Urban Water"
 "Greg Hunt",22/09/2008,08/12/2009,"Shadow Minister for Climate Change, Environment and Water"
-"Hon Tony Smith MP",03/03/2011,18/09/2013,"Deputy Chairman, Coalition Policy Development Committee"
-"Hon Tony Smith MP",03/03/2011,18/09/2013,"Shadow Parliamentary Secretary for Tax Reform"
+"The Hon Tony Smith MP",03/03/2011,18/09/2013,"Deputy Chairman, Coalition Policy Development Committee"
+"The Hon Tony Smith MP",03/03/2011,18/09/2013,"Shadow Parliamentary Secretary for Tax Reform"
 "Ian MacFarlane",22/09/2008,08/12/2009,"Shadow Minister for Energy and Resources"
 "Ian MacFarlane",14/09/2010,18/09/2013,"Shadow Minister for Energy and Resources"
 "Ian Macfarlane",08/12/2009,14/09/2010,"Shadow Minister for Infrastructure and Water"
@@ -692,11 +692,11 @@
 "Wayne Swan",26/10/2004,06/12/2007,"Shadow Treasurer"
 Bill Shorten MP,13/10/2013,02/06/2019,Leader of the Opposition
 Bill Shorten MP,06/12/2017,02/06/2019,"Shadow Minister for Indigenous Affairs and Aboriginal and Torres Strait Islanders (House)"
-Hon Bill Shorten MP,02/06/2019,,"Shadow Minister for the National Disability Insurance Scheme"
-Hon Bill Shorten MP,02/06/2019,,"Shadow Minister for Government Services"
+The Hon Bill Shorten MP,02/06/2019,,"Shadow Minister for the National Disability Insurance Scheme"
+The Hon Bill Shorten MP,02/06/2019,,"Shadow Minister for Government Services"
 Tanya Plibersek MP,18/10/2013,02/06/2019,Deputy Leader of the Opposition
 Tanya Plibersek MP,18/10/2013,06/12/2017,Shadow Minister for Foreign Affairs and International Development
-Hon Tanya Plibersek MP,06/12/2017,,Shadow Minister for Education and Training
+The Hon Tanya Plibersek MP,06/12/2017,,Shadow Minister for Education and Training
 Tanya Plibersek MP,06/12/2017,02/06/2019,Shadow Minister for Women
 Tanya Plibersek MP,06/12/2017,02/06/2019,"Shadow Minister for Skills, TAFE and Apprenticeships (House)"
 Tanya Plibersek MP,06/12/2017,02/06/2019,Shadow Minister for Foreign Affairs (House)
@@ -713,19 +713,19 @@ Senator Stephen Conroy,18/10/2013,06/12/2017,Shadow Minister for Defence
 Chris Bowen MP,18/10/2013,02/06/2019,Shadow Treasurer
 Chris Bowen MP,06/12/2017,21/08/2018,Acting Shadow Minister for Small Business and Financial Services
 Chris Bowen MP,21/08/2018,02/06/2019,Shadow Minister for Small Business
-Hon Chris Bowen MP,02/06/2019,,"Shadow Minister for Health"
+The Hon Chris Bowen MP,02/06/2019,,"Shadow Minister for Health"
 Tony Burke MP,18/10/2013,06/12/2017,Shadow Minister for Finance
 Tony Burke MP,18/10/2013,02/06/2019,Manager of Opposition Business (House)
 Tony Burke MP,06/12/2017,02/06/2019,Shadow Minister for Environment and Water
 Tony Burke MP,06/12/2017,02/06/2019,Shadow Minister for Citizenship and Multicultural Australia
-Hon Tony Burke MP,06/12/2017,,Shadow Minister for the Arts
-Hon Tony Burke MP,02/06/2019,,"Shadow Minister for Industrial Relations"
-Hon Tony Burke MP,02/06/2019,,"Manager of Opposition Business in the House of Representatives"
-Hon Mark Dreyfus QC MP,18/10/2013,,Shadow Attorney General
+The Hon Tony Burke MP,06/12/2017,,Shadow Minister for the Arts
+The Hon Tony Burke MP,02/06/2019,,"Shadow Minister for Industrial Relations"
+The Hon Tony Burke MP,02/06/2019,,"Manager of Opposition Business in the House of Representatives"
+The Hon Mark Dreyfus QC MP,18/10/2013,,Shadow Attorney General
 Mark Dreyfus QC MP,18/10/2013,06/12/2017,Shadow Minister for the Arts
 Mark Dreyfus QC MP,18/10/2013,02/06/2019,Deputy Manager of Opposition Business (House)
 Mark Dreyfus QC MP,06/12/2017,02/06/2019,Shadow Minister for National Security
-Hon Mark Dreyfus QC MP,02/06/2019,,"Shadow Minister for Constitutional Reform"
+The Hon Mark Dreyfus QC MP,02/06/2019,,"Shadow Minister for Constitutional Reform"
 Senator Kim Carr,18/10/2013,06/12/2017,Shadow Minister Assisting the Leader for Science
 Senator Kim Carr,18/10/2013,06/12/2017,"Shadow Minister for Higher Education, Research, Innovation and Industry"
 Senator Kim Carr,06/12/2017,02/06/2019,"Shadow Minister for Innovation, Industry, Science and Research"
@@ -735,43 +735,43 @@ Senator Kim Carr,06/12/2017,02/06/2019,Shadow Minister for Immigration and Borde
 Anthony Albanese MP,18/10/2013,06/12/2017,Shadow Minister for Infrastructure and Transport
 Anthony Albanese MP,18/10/2013,02/06/2019,Shadow Minister for Tourism
 Anthony Albanese MP,06/12/2017,02/06/2019,"Shadow Minister for Infrastructure, Transport, Cities and Regional Development"
-Hon Anthony Albanese MP,02/06/2019,,"Leader of the Opposition"
+The Hon Anthony Albanese MP,02/06/2019,,"Leader of the Opposition"
 Mark Butler MP,18/10/2013,06/12/2017,"Shadow Minister for Environment, Climate Change and Water"
-Hon Mark Butler MP,06/12/2017,,Shadow Minister for Climate Change and Energy
-Hon Mark Butler MP,02/06/2019,,"Deputy Manager of Opposition Business in the House of Representatives"
+The Hon Mark Butler MP,06/12/2017,,Shadow Minister for Climate Change and Energy
+The Hon Mark Butler MP,02/06/2019,,"Deputy Manager of Opposition Business in the House of Representatives"
 Jason Clare MP,18/10/2013,06/12/2017,Shadow Minister for Communications
 Jason Clare MP,06/12/2017,02/06/2019,Shadow Minister for Resources and Northern Australia
 Jason Clare MP,06/12/2017,02/06/2019,Shadow Minister for Trade and Investment
-Hon Jason Clare MP,02/06/2019,,"Shadow Minister for Regional Services, Territories and Local Government"
-Hon Jason Clare MP,02/06/2019,,"Shadow Minister for Housing and Homelessness"
+The Hon Jason Clare MP,02/06/2019,,"Shadow Minister for Regional Services, Territories and Local Government"
+The Hon Jason Clare MP,02/06/2019,,"Shadow Minister for Housing and Homelessness"
 Kate Ellis MP,18/10/2013,06/12/2017,Shadow Minister for Education
 Kate Ellis MP,18/10/2013,06/12/2017,Shadow Minister for Early Childhood
 Joel Fitzgibbon MP,18/10/2013,06/12/2017,Shadow Minister for Agriculture
 Joel Fitzgibbon MP,06/12/2017,02/06/2019,"Shadow Minister for Agriculture, Fisheries and Forestry"
 Joel Fitzgibbon MP,06/12/2017,02/06/2019,Shadow Minister for Rural and Regional Australia
-Hon Joel Fitzgibbon MP,02/06/2019,,"Shadow Minister for Agriculture and Resources"
+The Hon Joel Fitzgibbon MP,02/06/2019,,"Shadow Minister for Agriculture and Resources"
 Gary Gray AO MP,18/10/2013,06/12/2017,Shadow Minister for Resources
 Gary Gray AO MP,18/10/2013,06/12/2017,Shadow Minister for Northern Australia
 Gary Gray AO MP,18/10/2013,06/12/2017,Shadow Special Minister of State
 Catherine King MP,18/10/2013,06/12/2017,Shadow Minister for Health
 Catherine King MP,06/12/2017,02/06/2019,Shadow Minister for Health and Medicare
-Hon Catherine King MP,02/06/2019,,"Shadow Minister for Infrastructure, Transport and Regional Development"
+The Hon Catherine King MP,02/06/2019,,"Shadow Minister for Infrastructure, Transport and Regional Development"
 Jenny Macklin MP,18/10/2013,06/12/2017,Shadow Minister for Families and Payments
 Jenny Macklin MP,18/10/2013,06/12/2017,Shadow Minister for Disability Reform
 Jenny Macklin MP,06/12/2017,21/08/2018,Shadow Minister for Disability and Carers (House)
 Jenny Macklin MP,06/12/2017,21/08/2018,Shadow Minister for Families and Social Services
 Jenny Macklin MP,06/12/2017,21/08/2018,Shadow Minister for Housing and Homelessness
 Richard Marles MP,18/10/2013,06/12/2017,Shadow Minister for Immigration and Border Protection
-Hon Richard Marles MP,06/12/2017,,Shadow Minister for Defence
-Hon Richard Marles MP,02/06/2019,,"Deputy Leader of the Opposition"
+The Hon Richard Marles MP,06/12/2017,,Shadow Minister for Defence
+The Hon Richard Marles MP,02/06/2019,,"Deputy Leader of the Opposition"
 Shayne Neumann MP,18/10/2013,06/12/2017,Shadow Minister for Indigenous Affairs
 Shayne Neumann MP,18/10/2013,06/12/2017,Shadow Minister for Ageing
 Shayne Neumann MP,06/12/2017,02/06/2019,Shadow Minister for Immigration and Border Protection
-Hon Shayne Neumann MP,02/06/2019,,"Shadow Minister for Veterans' Affairs and Defence Personnel"
+The Hon Shayne Neumann MP,02/06/2019,,"Shadow Minister for Veterans' Affairs and Defence Personnel"
 Brendan O’Connor MP,18/10/2013,02/06/2019,Shadow Minister for Employment and Workplace Relations
-Hon Brendan O’Connor MP,02/06/2019,,"Shadow Minister for Employment and Industry"
-Hon Brendan O’Connor MP,02/06/2019,,"Shadow Minister for Science"
-Hon Brendan O’Connor MP,02/06/2019,,"Shadow Minister for Small and Family Business"
+The Hon Brendan O’Connor MP,02/06/2019,,"Shadow Minister for Employment and Industry"
+The Hon Brendan O’Connor MP,02/06/2019,,"Shadow Minister for Science"
+The Hon Brendan O’Connor MP,02/06/2019,,"Shadow Minister for Small and Family Business"
 Bernie Ripoll MP,18/10/2013,06/12/2017,Shadow Minister Assisting the Leader for Small Business
 Bernie Ripoll MP,18/10/2013,06/12/2017,Shadow Minister for Financial Services and Superannuation
 Bernie Ripoll MP,18/10/2013,06/12/2017,Shadow Minister for Sport
@@ -805,16 +805,16 @@ David Feeney MP,18/10/2013,06/12/2017,Shadow Assistant Minister for Defence
 Julie Collins MP,18/10/2013,06/12/2017,Shadow Minister for Regional Development and Local Government
 Julie Collins MP,18/10/2013,06/12/2017,Shadow Minister for Employment Services
 Julie Collins MP,06/12/2017,02/06/2019,Shadow Minister for Ageing and Mental Health
-Hon Julie Collins MP,02/06/2019,,"Shadow Minister for Ageing and Seniors"
-Hon Julie Collins MP,02/06/2019,,"Shadow Minister for Women"
+The Hon Julie Collins MP,02/06/2019,,"Shadow Minister for Ageing and Seniors"
+The Hon Julie Collins MP,02/06/2019,,"Shadow Minister for Women"
 Dr Andrew Leigh MP,18/10/2013,02/06/2019,Shadow Assistant Treasurer
 Dr Andrew Leigh MP,18/10/2013,06/12/2017,Shadow Minister for Competition
 Dr Andrew Leigh MP,06/12/2017,02/06/2019,Shadow Minister for Competition and Productivity
 Dr Andrew Leigh MP,06/12/2017,02/06/2019,Shadow Minister for Charities and Not-for-Profits
 Dr Andrew Leigh MP,06/12/2017,02/06/2019,"Shadow Minister for Innovation, Industry, Science and Research (House)"
 Dr Andrew Leigh MP,06/12/2017,02/06/2019,Shadow Minister for Trade in Services
-Hon Dr Andrew Leigh MP,02/06/2019,,"Shadow Assistant Minister for Treasury"
-Hon Dr Andrew Leigh MP,02/06/2019,,"Shadow Assistant Minister for Charities"
+The Hon Dr Andrew Leigh MP,02/06/2019,,"Shadow Assistant Minister for Treasury"
+The Hon Dr Andrew Leigh MP,02/06/2019,,"Shadow Assistant Minister for Charities"
 Sharon Bird MP,18/10/2013,06/12/2017,Shadow Minister for Vocational Education
 Michelle Rowland MP,18/10/2013,06/12/2017,Shadow Assistant Minister for Communications
 Michelle Rowland MP,18/10/2013,06/12/2017,Shadow Minister for Citizenship and Multiculturalism
@@ -861,8 +861,8 @@ Matt Thistlethwaite MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for 
 Matt Thistlethwaite MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Immigration
 Matt Thistlethwaite MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Treasury
 Matt Thistlethwaite MP,06/12/2017,02/06/2019,Shadow Assistant Minister for an Australian Head of State
-Hon Matt Thistlethwaite MP,02/06/2019,,"Shadow Assistant Minister for Financial Services"
-Hon Matt Thistlethwaite MP,02/06/2019,,"Shadow Assistant Minister for the Republic"
+The Hon Matt Thistlethwaite MP,02/06/2019,,"Shadow Assistant Minister for Financial Services"
+The Hon Matt Thistlethwaite MP,02/06/2019,,"Shadow Assistant Minister for the Republic"
 Gai Brodtmann MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Defence
 Gai Brodtmann MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Cyber Security and Defence
 Stephen Jones MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Regional Development and Infrastructure
@@ -873,11 +873,11 @@ Stephen Jones MP,02/06/2019,,"Shadow Minister for Financial Services"
 Warren Snowdon MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for External Territories
 Warren Snowdon MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Northern Australia
 Warren Snowdon MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Indigenous Affairs
-Hon Warren Snowdon MP,06/12/2017,,Shadow Assistant Minister for External Territories
+The Hon Warren Snowdon MP,06/12/2017,,Shadow Assistant Minister for External Territories
 Warren Snowdon MP,06/12/2017,02/06/2019,Shadow Assistant Minister for the Centenary of ANZAC
 Warren Snowdon MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Indigenous Health
-Hon Warren Snowdon MP,06/12/2017,,Shadow Assistant Minister for Northern Australia
-Hon Warren Snowdon MP,02/06/2019,,"Shadow Assistant Minister for Indigenous Australians"
+The Hon Warren Snowdon MP,06/12/2017,,Shadow Assistant Minister for Northern Australia
+The Hon Warren Snowdon MP,02/06/2019,,"Shadow Assistant Minister for Indigenous Australians"
 Ed Husic MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary to the Shadow Treasurer
 Ed Husic MP,06/12/2017,02/06/2019,Shadow Minister for the Digital Economy
 Ed Husic MP,06/12/2017,21/08/2018,"Shadow Minister for Employment Services, Workforce Participation and Future of Work"
@@ -898,8 +898,8 @@ Amanda Rishworth MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Hea
 Amanda Rishworth MP,06/12/2017,02/06/2019,Shadow Minister for Veterans' Affairs
 Amanda Rishworth MP,06/12/2017,02/06/2019,Shadow Minister for Defence Personnel
 Amanda Rishworth MP,06/12/2017,02/06/2019,Shadow Minister for Early Childhood Education and Development
-Hon Amanda Rishworth MP,02/06/2019,,"Shadow Minister for Early Childhood Education"
-Hon Amanda Rishworth MP,02/06/2019,,"Shadow Minister for Youth"
+The Hon Amanda Rishworth MP,02/06/2019,,"Shadow Minister for Early Childhood Education"
+The Hon Amanda Rishworth MP,02/06/2019,,"Shadow Minister for Youth"
 Senator Carol Brown,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Families and Payments
 Senator Carol Brown,06/12/2017,02/06/2019,Shadow Minister for Disability and Carers
 Senator Carol Brown,06/12/2017,02/06/2019,Shadow Minister for Tourism (Senate)
@@ -931,10 +931,10 @@ Tim Hammond MP,06/12/2017,21/08/2018,Shadow Minister for Consumer Affairs
 Tim Hammond MP,06/12/2017,21/08/2018,Shadow Minister Assisting for Resources
 Linda Burney MP,06/12/2017,21/08/2018,Shadow Minister for Human Services
 Linda Burney MP,21/08/2018,02/06/2019,Shadow Minister for Preventing Family Violence
-Hon Linda Burney MP,21/08/2018,,Shadow Minister for Families and Social Services
+The Hon Linda Burney MP,21/08/2018,,Shadow Minister for Families and Social Services
 Linda Burney MP,21/08/2018,02/06/2019,Shadow Minister for Housing and Homelessness (House)
 Linda Burney MP,21/08/2018,02/06/2019,Shadow Minister for Disability and Carers (House)
-Hon Linda Burney MP,02/06/2019,,"Shadow Minister for Indigenous Australians"
+The Hon Linda Burney MP,02/06/2019,,"Shadow Minister for Indigenous Australians"
 Pat Conroy MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Infrastructure
 Pat Conroy MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Climate Change and Energy
 Pat Conroy MP,02/06/2019,,"Shadow Minister for International Development and the Pacific"
@@ -946,7 +946,7 @@ Clare O'Neil MP,02/06/2019,,"Shadow Minister for Innovation, Technology and the 
 Lisa Chesters MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Workplace Relations
 Lisa Chesters MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Rural and Regional Australia
 Mike Kelly AM MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Defence Industry and Support
-Hon Dr Mike Kelly AM MP,02/06/2019,,"Shadow Assistant Minister for Defence"
+The Hon Dr Mike Kelly AM MP,02/06/2019,,"Shadow Assistant Minister for Defence"
 Nick Champion MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Manufacturing and Science
 Senator Deborah O'Neill,06/12/2017,02/06/2019,Shadow Assistant Minister for Innovation
 Senator Deborah O'Neill,06/12/2017,02/06/2019,Shadow Minister for Communications (Senate)


### PR DESCRIPTION
Note: I've written out the names of the ministers as included in the Shadow Ministry [document](https://www.aph.gov.au/Senators_and_Members), which means I've added "Hon" to several titles. Previously, Labor have often left off those parts, but since it's there, I though it should be added with this update. Let me know if these additions cause an issue.