### PR TITLE
Andrew McLachlan joins Senate

### DIFF
--- a/data/people.csv
+++ b/data/people.csv
@@ -983,3 +983,4 @@ person count,aph id,name,birthday,alt name
 956,252157,Jess Walsh,,Jessica Cecille Walsh
 957,283601,David Van,,David Allan Van
 958,283585,Matt O'Sullivan,,Matthew Anthony O'Sullivan
+959,287062,Andrew McLachlan,,Andrew Lockhart McLachlan


### PR DESCRIPTION
New senator for South Australia: [Andrew McLachlan](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=287062)