### PR TITLE
Eden-Monaro MP has resigned; spot currently vacant

### DIFF
--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -686,7 +686,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 687,,Julia Banks,Chisholm,Vic,2.7.2016,,27.11.2018,changed_party,LIB
 688,,Anne Aly,Cowan,WA,2.7.2016,,,still_in_office,ALP
 689,,Emma McBride,Dobell,NSW,2.7.2016,,,still_in_office,ALP
-690,,Michael Joseph Kelly,Eden-Monaro,NSW,2.7.2016,,,still_in_office,ALP
+690,,Michael Joseph Kelly,Eden-Monaro,NSW,2.7.2016,,30.4.2020,resigned,ALP
 691,,Ted O'Brien,Fairfax,QLD,2.7.2016,,,still_in_office,LIB
 692,,Cathy O'Toole,Herbert,QLD,2.7.2016,,18.05.2019,defeated,ALP
 693,,Steve Georganas,Hindmarsh,SA,2.7.2016,,18.05.2019,elected_elsewhere,ALP


### PR DESCRIPTION
MP Mike Kelly [resigned 30.4.2020](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=HRI) and has yet to be replaced. Due to the COVID-19 pandemic, the date of the forthcoming by-election has [yet to be announced](https://www.abc.net.au/news/elections/eden-monaro-by-election-2020/).