### PR TITLE
Kristy McBain elected to Eden-Monaro

### DIFF
--- a/data/people.csv
+++ b/data/people.csv
@@ -984,3 +984,4 @@ person count,aph id,name,birthday,alt name
 957,283601,David Van,,David Allan Van
 958,283585,Matt O'Sullivan,,Matthew Anthony O'Sullivan
 959,287062,Andrew McLachlan,,Andrew Lockhart McLachlan
+960,281988,Kristy McBain,,Kristy Louise McBain


### PR DESCRIPTION
Eden-Monaro by-election on 4 July 2020.