### PR TITLE
Kristy McBain elected to Eden-Monaro

### DIFF
--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -771,3 +771,4 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 770,,Damian Drum,Nicholls,Vic,18.05.2019,elected_elsewhere,,still_in_office,NP
 771,,Ged Kearney,Cooper,Vic,18.05.2019,elected_elsewhere,,still_in_office,ALP
 772,,David Philip Benedict Smith,Bean,ACT,18.05.2019,,,still_in_office,ALP
+773,,Kristy McBain,Eden-Monaro,NSW,4.7.2020,by_election,,still_in_office,ALP


### PR DESCRIPTION
By-election on 4 July 2020.