### PR TITLE
Di Natale resigned 26/08

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -285,7 +285,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 72,,Christopher Martin Ellison,,WA,1.7.1993,,30.1.2009,resigned,LIB
 279,,Christopher John Back,,WA,11.3.2009,,31.7.2017,resigned,LIB
 # Next available Senator number is: 280,,,,,,,,,
-285,,Richard Di Natale,,Victoria,1.7.2011,,,still_in_office,GRN
+285,,Richard Di Natale,,Victoria,1.7.2011,,26.8.2020,resigned,GRN
 286,,Sean Edwards,,SA,1.7.2011,,9.5.2016,defeated,LIB
 287,,David Fawcett,,SA,1.7.2011,,,still_in_office,LIB
 288,,Alex Gallacher,,SA,1.7.2011,,,still_in_office,ALP


### PR DESCRIPTION
Victorian Greens Senator Richard Di Natale [resigned on 26.8.2020](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=53369). He has not yet been replaced and, with the COVID situation in Victoria, it might take a while for that to happen.