### PR TITLE
Senator Lidia Thorpe appointed to Senate

### DIFF
--- a/data/people.csv
+++ b/data/people.csv
@@ -985,3 +985,4 @@ person count,aph id,name,birthday,alt name
 958,283585,Matt O'Sullivan,,Matthew Anthony O'Sullivan
 959,287062,Andrew McLachlan,,Andrew Lockhart McLachlan
 960,281988,Kristy McBain,,Kristy Louise McBain
+961,280304,Lidia Thorpe,,Lidia Alma Thorpe


### PR DESCRIPTION
Chosen by the Parliament of Victoria on 4.9.2020 under section 15 of the Constitution to represent that State in the Senate after R Di Natale (resigned).