### PR TITLE
McVeigh MP resigned

### DIFF
--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -711,7 +711,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 712,,Ben Morton,Tangney,WA,2.7.2016,,,still_in_office,LIB
 713,,Peter Khalil,Wills,Vic.,2.7.2016,,,still_in_office,ALP
 714,,Julian Leeser,Berowra,NSW,2.7.2016,,,still_in_office,LIB
-715,,John McVeigh,Groom,Qld,2.7.2016,,,still_in_office,LIB
+715,,John McVeigh,Groom,Qld,2.7.2016,,18.9.2020,resigned,LIB
 716,,David Littleproud,Maranoa,Qld,2.7.2016,,,still_in_office,NP
 717,,Tim Hammond,Perth,WA,2.7.2016,,10.5.2018,resigned,ALP
 718,,Llew O'Brien,Wide Bay,Qld,2.7.2016,,,still_in_office,NP


### PR DESCRIPTION
Groom MP John McVeigh [resigned 18.9.2020](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=125865). By-election to be held [28 November 2020](https://www.aec.gov.au/groom/).