### PR TITLE
Senator Cormann resigned 6/11

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -58,7 +58,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 54,,Peter Francis Salmon Cook,,WA,5.3.1983,,30.6.2005,retired,ALP
 55,,Helen Lloyd Coonan,,NSW,1.7.1996,,22.8.2011,resigned,LIB
 56,,Bernard Cornelius Cooney,,Vic.,1.12.1984,,30.6.2002,retired,ALP
-57,,Mathias Hubert Paul Cormann,,WA,19.6.2007,section_15,,still_in_office,LIB
+57,,Mathias Hubert Paul Cormann,,WA,19.6.2007,section_15,6.11.2020,resigned,LIB
 58,,John Richard Coulter,,SA,11.7.1987 ,,20.11.1995 ,resigned,AD
 59,,Arthur Winston Crane,,WA,1.7.1990 ,,30.6.2002 ,defeated,LIB
 60,,Noel Ashley Crichton-Browne,,WA,1.7.1981 ,,30.6.1996 ,retired,IND LIB


### PR DESCRIPTION
His replacement has been named - Ben Small - but not yet signed off by WA Parliament, which should happen in late November.