### PR TITLE
Ben Small joins Senate

### DIFF
--- a/data/people.csv
+++ b/data/people.csv
@@ -986,3 +986,4 @@ person count,aph id,name,birthday,alt name
 959,287062,Andrew McLachlan,,Andrew Lockhart McLachlan
 960,281988,Kristy McBain,,Kristy Louise McBain
 961,280304,Lidia Thorpe,,Lidia Alma Thorpe
+962,291406,Ben Small,,Benjamin John Small


### PR DESCRIPTION
[Ben Small](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=291406) has replaced Senator Cormann