### PR TITLE
Ben Small joins Senate

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -410,3 +410,4 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 923,,Andrew McLachlan,,SA,6.2.2020,section_15,,still_in_office,LIB
 924,,Rex Patrick,,SA,10.8.2020,changed_party,,still_in_office,IND
 925,,Lidia Thorpe,,Vic,4.9.2020,section_15,,still_in_office,GRN
+926,,Ben Small,,WA,25.11.2020,section_15,,still_in_office,LIB


### PR DESCRIPTION
The Parliament of WA has chose [Ben Small](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=291406) to replace Senator Cormann this week on 25/11/2020.