### PR TITLE
New MP for Groom Garth Hamilton

### DIFF
--- a/data/people.csv
+++ b/data/people.csv
@@ -987,3 +987,4 @@ person count,aph id,name,birthday,alt name
 960,281988,Kristy McBain,,Kristy Louise McBain
 961,280304,Lidia Thorpe,,Lidia Alma Thorpe
 962,291406,Ben Small,,Benjamin John Small
+963,291387,Garth Hamilton,,Garth Russell Hamilton


### PR DESCRIPTION
The new MP for Groom [Garth Hamilton](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=291387) was sworn in this week.