### PR TITLE
New MP for Groom Garth Hamilton

### DIFF
--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -772,3 +772,4 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 771,,Ged Kearney,Cooper,Vic,18.05.2019,elected_elsewhere,,still_in_office,ALP
 772,,David Philip Benedict Smith,Bean,ACT,18.05.2019,,,still_in_office,ALP
 773,,Kristy McBain,Eden-Monaro,NSW,4.7.2020,by_election,,still_in_office,ALP
+774,,Garth Hamilton,Groom,QLD,3.12.2020,by_election,,still_in_office,LNP


### PR DESCRIPTION
New MP for Groom [Garth Hamilton](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=291387) was sworn in on 3/12/2020. By-election was held on 28/11/2020.