### PR TITLE
The second "Second" Morrison Ministry

### DIFF
--- a/data/ministers.csv
+++ b/data/ministers.csv
@@ -570,8 +570,10 @@ The Hon Malcolm Turnbull MP,18/09/2013,21/09/2015,Minister for Communications
 The Hon Peter Dutton MP,18/09/2013,23/11/2014,Minister for Health
 The Hon Peter Dutton MP,18/09/2013,23/11/2014,Minister for Sport
 The Hon Peter Dutton MP,23/11/2014,26/08/2018,Minister for Immigration and Border Protection
-The Hon Peter Dutton MP,20/12/2017,,"Minister for Home Affairs"
+The Hon Peter Dutton MP,20/12/2017,30/03/2021,"Minister for Home Affairs"
 The Hon Peter Dutton MP,02/03/2019,29/05/2019,"Minister for Emergency Management and North Queensland Recovery in the House"
+The Hon Peter Dutton MP,30/03/2021,,"Minister for Defence"
+The Hon Peter Dutton MP,30/03/2021,,"Leader of the House"
 The Hon Bruce Billson MP,18/09/2013,21/09/2015,Minister for Small Business
 The Hon Andrew Robb AO MP,18/09/2013,18/02/2016,Minister for Trade and Investment
 Senator the Hon David Johnston,18/09/2013,23/11/2014,Minister for Defence
@@ -637,8 +639,9 @@ The Hon Stuart Robert MP,21/09/2015,30/08/2016,Minister for Veterans’ Affairs
 The Hon Stuart Robert MP,21/09/2015,30/08/2016,Minister Assisting the Prime Minister for the Centenary of ANZAC
 The Hon Stuart Robert MP,21/09/2015,20/12/2017,Minister for Human Services
 The Hon Stuart Robert MP,26/08/2018,29/05/2019,Assistant Treasurer
-The Hon Stuart Robert MP,29/05/2019,,"Minister for the National Disability Insurance Scheme"
-The Hon Stuart Robert MP,29/05/2019,,"Minister for Government Services"
+The Hon Stuart Robert MP,29/05/2019,30/03/2021,"Minister for the National Disability Insurance Scheme"
+The Hon Stuart Robert MP,29/05/2019,30/03/2021,"Minister for Government Services"
+The Hon Stuart Robert MP,30/03/2021,,"Minister for Employment, Workforce, Skills, Small and Family Business"
 Senator the Hon Michaelia Cash,18/09/2013,21/09/2015,Assistant Minister for Immigration and Border Protection
 Senator the Hon Michaelia Cash,18/09/2013,21/09/2015,Minister Assisting the Prime Minister for Women
 Senator the Hon Michaelia Cash,21/09/2015,20/12/2017,Minister for Women
@@ -646,8 +649,10 @@ Senator the Hon Michaelia Cash,21/09/2015,20/12/2017,Minister Assisting the Prim
 Senator the Hon Michaelia Cash,21/09/2015,20/12/2017,Minister for Employment
 Senator the Hon Michaelia Cash,20/12/2017,26/08/2018,"Minister for Jobs and Innovation"
 Senator the Hon Michaelia Cash,26/08/2018,29/05/2019,Minister for Small and Family Business, Skills and Vocational Education
-Senator the Hon Michaelia Cash,29/05/2019,,"Minister for Employment, Skills, Small and Family Business"
+Senator the Hon Michaelia Cash,29/05/2019,30/03/2021,"Minister for Employment, Skills, Small and Family Business"
 Senator the Hon Michaelia Cash,22/12/2020,,"Deputy Leader of the Government in the Senate"
+Senator the Hon Michaelia Cash,30/03/2021,,"Attorney-General"
+Senator the Hon Michaelia Cash,30/03/2021,,"Minister for Industrial Relations"
 The Hon Jamie Briggs MP,18/09/2013,21/09/2015,Assistant Minister for Infrastructure and Regional Development
 The Hon Jamie Briggs MP,21/09/2015,30/12/2015,Minister for Cities and the Built Environment
 Senator the Hon Arthur Sinodinos AO,18/09/2013,19/12/2014,Assistant Treasurer
@@ -721,13 +726,15 @@ The Hon Michael McCormack MP,20/12/2017,05/03/2018,Deputy Leader of the House
 The Hon Michael McCormack MP,20/12/2017,05/03/2018,"Minister Assisting the Prime Minister for the Centenary of ANZAC"
 The Hon Christian Porter MP,23/11/2014,21/09/2015,Parliamentary Secretary to the Prime Minister
 The Hon Christian Porter MP,21/09/2015,20/12/2017,Minister for Social Services
-The Hon Christian Porter MP,20/12/2017,,Attorney-General
-The Hon Christian Porter MP,29/05/2019,,"Leader of the House"
-The Hon Christian Porter MP,29/05/2019,,"Minister for Industrial Relations"
+The Hon Christian Porter MP,20/12/2017,30/03/2021,Attorney-General
+The Hon Christian Porter MP,29/05/2019,30/03/2021,"Leader of the House"
+The Hon Christian Porter MP,29/05/2019,30/03/2021,"Minister for Industrial Relations"
+The Hon Christian Porter MP,29/05/2019,30/03/2021,"Minister for Industry, Science and Technology"
 The Hon Karen Andrews MP,23/11/2014,21/09/2015,Parliamentary Secretary to the Minister for Industry and Science
 The Hon Karen Andrews MP,30/09/2015,21/09/2015,Assistant Minister for Science
 The Hon Karen Andrews MP,30/08/2016,26/08/2018,"Assistant Minister for Vocational Education and Skills"
-The Hon Karen Andrews MP,26/08/2018,,Minister for Industry, Science and Technology
+The Hon Karen Andrews MP,26/08/2018,30/03/2021,Minister for Industry, Science and Technology
+The Hon Karen Andrews MP,30/03/2021,,"Minister for Home Affairs"
 The Hon Kelly O’Dwyer MP,23/11/2014,21/09/2015,Parliamentary Secretary to the Treasurer
 The Hon Kelly O’Dwyer MP,21/09/2015,30/08/2016,Minister for Small Business
 The Hon Kelly O’Dwyer MP,21/09/2015,30/08/2016,Assistant Treasurer
@@ -749,6 +756,7 @@ Senator the Hon Anne Ruston,21/09/2015,26/08/2018,Assistant Minister for Agricul
 Senator the Hon Anne Ruston,26/08/2018,29/05/2019,Assistant Minister for International Development and the Pacific
 Senator the Hon Anne Ruston,29/05/2019,,"Minister for Families and Social Services"
 Senator the Hon Anne Ruston,29/05/2019,,"Manager of Government Business in the Senate"
+Senator the Hon Anne Ruston,30/03/2021,,"Minister for Women's Safety"
 The Hon Wyatt Roy MP,21/09/2015,19/07/2016,Assistant Minister for Innovation
 The Hon Ken Wyatt AM MP,21/09/2015,30/08/2016,Assistant Minister for Health
 The Hon Ken Wyatt AM MP,30/08/2016,24/01/2017,"Assistant Minister for Health And Aged Care"
@@ -830,7 +838,9 @@ Senator the Hon Linda Reynolds CSC,02/03/2019,29/05/2019,"Minister for Veterans'
 Senator the Hon Linda Reynolds CSC,02/03/2019,29/05/2019,"Minister for Defence Personnel in the Senate"
 Senator the Hon Linda Reynolds CSC,02/03/2019,29/05/2019,"Minister Assisting the Prime Minister for the Centenary of ANZAC in the Senate"
 Senator the Hon Linda Reynolds CSC,02/03/2019,29/05/2019,"Minister for Emergency Management and North Queensland Recovery"
-Senator the Hon Linda Reynolds CSC,29/05/2019,,"Minister for Defence"
+Senator the Hon Linda Reynolds CSC,29/05/2019,30/03/2021,"Minister for Defence"
+Senator the Hon Linda Reynolds CSC,30/03/2021,,"Minister for Government Services"
+Senator the Hon Linda Reynolds CSC,30/03/2021,,"Minister for the National Disability Insurance Scheme"
 The Hon Sarah Henderson MP,26/08/2018,29/05/2019,Assistant Minister for Social Services, Housing and Disability Services
 The Hon Michelle Landry MP,26/08/2018,06/02/2020,Assistant Minister for Children and Families
 The Hon Michelle Landry MP,06/02/2020,,"Assistant Minister for Northern Australia"
@@ -844,6 +854,7 @@ The Hon Andrew Gee MP,06/02/2020,,"Minister Assisting the Minister for Trade and
 The Hon Nola Marino MP,29/05/2019,,"Assistant Minister for Regional Development and Territories"
 Senator the Hon Jane Hume,29/05/2019,22/12/2020,"Assistant Minister for Superannuation, Financial Services and Financial Technology"
 Senator the Hon Jane Hume,22/12/2020,,"Minister for Superannuation, Financial Services and the Digital Economy"
+Senator the Hon Jane Hume,30/03/2021,,"Minister for Women's Economic Security"
 Senator the Hon Jonathon Duniam,29/05/2019,,"Assistant Minister for Forestry and Fisheries"
 Senator the Hon Jonathon Duniam,29/05/2019,22/12/2020,"Assistant Minister for Regional Tourism"
 Senator the Hon Jonathon Duniam,22/12/2020,,"Assistant Minister for Industry Development"
@@ -853,4 +864,6 @@ The Hon Luke Howarth MP,29/05/2019,22/12/2020,"Assistant Minister for Community 
 The Hon Luke Howarth MP,22/12/2020,,"Assistant Minister for Youth and Employment Services"
 The Hon Kevin Hogan MP,06/02/2020,,"Assistant Minister to the Deputy Prime Minister"
 Senator the Hon Amanda Stoker,22/12/2020,,"Assistant Minister to the Attorney-General"
+Senator the Hon Amanda Stoker,30/03/2021,,"Assistant Minister for Women"
+Senator the Hon Amanda Stoker,30/03/2021,,"Assistant Minister for Industrial Relations"
 The Hon Andrew Hastie MP,22/12/2020,,"Assistant Minister for Defence"


### PR DESCRIPTION
The latest Morrison ministry, properly called the "third" but for some reason titled the "second" (perhaps they are embarrassed about having so many changes so soon after the last lot). Updated 30 March 2021.