### PR TITLE
Joyce replaces McCormack June '21

### DIFF
--- a/data/ministers.csv
+++ b/data/ministers.csv
@@ -553,6 +553,8 @@ The Hon Barnaby Joyce MP,30/08/2016,20/12/2017,"Deputy Prime Minister and Minist
 The Hon Barnaby Joyce MP,18/09/2013,11/02/2016,Deputy Leader of the Nationals
 The Hon Barnaby Joyce MP,11/02/2016,26/02/2018,Leader of the Nationals
 The Hon Barnaby Joyce MP,20/12/2017,26/02/2018,"Deputy Prime Minister and Minister for Infrastructure and Transport"
+The Hon Barnaby Joyce MP,22/06/2021,,"Leader of the Nationals"
+The Hon Barnaby Joyce MP,22/06/2021,,"Deputy Prime Minister and Minister for Infrastructure, Transport and Regional Development"
 The Hon Christopher Pyne MP,18/09/2013,23/11/2014,Minister for Education
 The Hon Christopher Pyne MP,23/11/2014,21/09/2015,Minister for Education and Training
 "The Hon Christopher Pyne MP",21/09/2015,30/08/2016,"Minister for Industry, Innovation and Science"
@@ -811,9 +813,9 @@ The Hon Melissa Price MP,29/05/2019,,"Minister for Defence Industry"
 The Hon David Littleproud MP,20/12/2017,29/05/2019,"Minister for Agriculture and Water Resources"
 The Hon David Littleproud MP,29/05/2019,06/02/2020,"Minister for Water Resources, Drought, Rural Finance, Natural Disaster and Emergency Management"
 The Hon David Littleproud MP,06/02/2020,,"Minister for Agriculture, Drought and Emergency Management"
-The Hon Michael McCormack MP,26/02/2018,,"Leader of the Nationals"
+The Hon Michael McCormack MP,26/02/2018,22/06/2021,"Leader of the Nationals"
 The Hon Michael McCormack MP,05/03/2018,29/05/2019,"Deputy Prime Minister and Minister for Infrastructure and Transport"
-The Hon Michael McCormack MP,29/05/2019,,"Deputy Prime Minister and Minister for Infrastructure, Transport and Regional Development"
+The Hon Michael McCormack MP,29/05/2019,22/06/2021,"Deputy Prime Minister and Minister for Infrastructure, Transport and Regional Development"
 The Hon Darren Chester MP,05/03/2018,29/05/2019,"Minister for Veterans' Affairs"
 The Hon Darren Chester MP,05/03/2018,29/05/2019,"Minister for Defence Personnel"
 The Hon Darren Chester MP,05/03/2018,29/05/2019,"Minister Assisting the Prime Minister for the Centenary of ANZAC"


### PR DESCRIPTION
According to their official minister pages, [Joyce](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=e5d) not only replaced [McCormack](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=219646) in leading the party, but also took his portfolio in Infrastructure, Transport and Regional Development. This hasn't been updated in the Ministry list yet, but that will probably wait for Morrison to return to Australia.