### PR TITLE
SA Sen Alex Gallacher has died 29.8.2021

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -288,7 +288,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 285,,Richard Di Natale,,Victoria,1.7.2011,,26.8.2020,resigned,GRN
 286,,Sean Edwards,,SA,1.7.2011,,9.5.2016,defeated,LIB
 287,,David Fawcett,,SA,1.7.2011,,,still_in_office,LIB
-288,,Alex Gallacher,,SA,1.7.2011,,,still_in_office,ALP
+288,,Alex Gallacher,,SA,1.7.2011,,29.8.2021,died,ALP
 291,,Bridget McKenzie,,Victoria,1.7.2011,,,still_in_office,NP
 292,,John Madigan,,Victoria,1.7.2011,,4.9.2014,changed_party,DLP
 293,,Lee Rhiannon,,NSW,1.7.2011,,18.08.2018,resigned,GRN


### PR DESCRIPTION
SA Senator Gallacher [passed away last week](https://www.abc.net.au/news/2021-08-30/sa-labor-senator-alex-gallacher-dies-after-lung-cancer-battle/100418876). A new SA senator has not yet been announced.