### PR TITLE
New WA Senator Dorinda Cox

### DIFF
--- a/data/people.csv
+++ b/data/people.csv
@@ -988,3 +988,4 @@ person count,aph id,name,birthday,alt name
 961,280304,Lidia Thorpe,,Lidia Alma Thorpe
 962,291406,Ben Small,,Benjamin John Small
 963,291387,Garth Hamilton,,Garth Russell Hamilton
+964,296215,Dorinda Cox,,Dorinda Rose Cox


### PR DESCRIPTION
Senator Dorinda Cox has replaced Rachel Siewert as WA Senator with the Greens Party