### PR TITLE
New Victorian Senator - Mirabella

### DIFF
--- a/data/people.csv
+++ b/data/people.csv
@@ -990,3 +990,4 @@ person count,aph id,name,birthday,alt name
 963,291387,Garth Hamilton,,Garth Russell Hamilton
 964,296215,Dorinda Cox,,Dorinda Rose Cox
 965,296331,Karen Grogan,,
+966,286349,Greg Mirabella,,


### PR DESCRIPTION
[Greg Mirabella](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=286349) chosen by Vic Parliament for the Senate