### PR TITLE
Craig Kelly to UAP

### DIFF
--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -773,6 +773,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 772,,David Philip Benedict Smith,Bean,ACT,18.05.2019,,,still_in_office,ALP
 773,,Kristy McBain,Eden-Monaro,NSW,4.7.2020,by_election,,still_in_office,ALP
 774,,Garth Hamilton,Groom,QLD,3.12.2020,by_election,,still_in_office,LNP
-775,,Craig Kelly,Hughes,NSW,23.2.2021,changed_party,,still_in_office,IND
+775,,Craig Kelly,Hughes,NSW,23.2.2021,changed_party,23.8.2021,changed_party,IND
 776,,Anthony David Hawthorn Smith,Casey,Vic,23.11.2021,changed_party,,still_in_office,LIB
 777,,Andrew Wallace,Fisher,QLD,23.11.2021,changed_party,,still_in_office,SPK
+778,,Craig Kelly,Hughes,NSW,23.8.2021,changed_party,,still_in_office,UAP


### PR DESCRIPTION
I missed updating Craig Kelly's new party last year - since [23 Aug 2021](https://www.unitedaustraliaparty.org.au/craig-kelly-appointed-leader-of-the-united-australia-party/) he's been in United Australia Party