### PR TITLE
Spence MP Nick Champion resigned

### DIFF
--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -766,7 +766,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 765,,Steve Georganas,Adelaide,SA,18.05.2019,elected_elsewhere,,still_in_office,ALP
 766,,Russell Evan Broadbent,Monash,Vic,18.05.2019,elected_elsewhere,,still_in_office,LIB
 767,,Mark Christopher Butler,Hindmarsh,SA,18.05.2019,elected_elsewhere,,still_in_office,ALP
-768,,Nicholas David Champion,Spence,SA,18.05.2019,elected_elsewhere,,still_in_office,ALP
+768,,Nicholas David Champion,Spence,SA,18.05.2019,elected_elsewhere,22.02.2022,resigned,ALP
 769,,Andrew Wilkie,Clark,Tas,18.05.2019,elected_elsewhere,,still_in_office,IND
 770,,Damian Drum,Nicholls,Vic,18.05.2019,elected_elsewhere,,still_in_office,NP
 771,,Ged Kearney,Cooper,Vic,18.05.2019,elected_elsewhere,,still_in_office,ALP


### PR DESCRIPTION
Spence MP Nick Champion [resigned on 22.2.22](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=HW9) to take part in SA election. He has not yet been replaced - perhaps won't before the election.