### PR TITLE
Vic Senator Kitching died in office

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -349,7 +349,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 862,,Louise Pratt,,WA,1.7.2016,,,still_in_office,ALP
 863,,Malcolm Roberts,,QLD,1.7.2016,,27.10.2017,disqualified,PHON
 864,,Murray Watt,,QLD,1.7.2016,,,still_in_office,ALP
-865,,Kimberley Kitching,,Vic.,25.10.2016,section_15,,still_in_office,ALP
+865,,Kimberley Kitching,,Vic.,25.10.2016,section_15,10.3.2022,died,ALP
 866,,Cory Bernardi,,SA,7.2.2017,changed_party,20.1.2020,resigned,AC
 867,,Nick Xenophon,,SA,1.7.2013,changed_party,31.10.2017,resigned,NXT
 868,,Peter Georgiou,,WA,20.3.2017,,1.7.2019,defeated,PHON


### PR DESCRIPTION
Vic Senator Kitching [died in office on 10.3.2022](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=247512). Her place has not yet been filled, and perhaps won't before the next election.