### PR TITLE
Dutton Shadow Ministry 05 June 2022

### DIFF
--- a/data/shadow-ministers.csv
+++ b/data/shadow-ministers.csv
@@ -163,6 +163,7 @@
 "Jamie Briggs",14/09/2010,18/09/2013,"Chairman of the Scrutiny of Government Waste Committee"
 "Jason Wood",22/09/2008,08/12/2009,"Shadow Parliamentary Secretary for Justice and Public Security"
 "Jason Wood",08/12/2009,14/09/2010,"Shadow Parliamentary Secretary for Public Security and Policing"
+"The Hon Jason Wood MP",05/06/2022,,"Shadow Minister for Community Safety, Migrant Services and Multicultural Affairs"
 "Jennie George",26/10/2004,06/12/2007,"Shadow Parliamentary Secretary for Environment and Heritage"
 "Jenny Macklin",26/08/1997,21/10/1998,"Assistant to the Leader of the Opposition on the Status of Women"
 "Jenny Macklin",23/11/2001,04/12/2006,"Deputy Leader of the Opposition"
@@ -371,6 +372,7 @@
 "Senator Barnaby Joyce",14/09/2010,18/09/2013,"Leader of The Nationals in the Senate"
 "Senator Barnaby Joyce",08/12/2009,14/09/2010,"Shadow Minister for Finance and Debt Reduction"
 "Senator Barnaby Joyce",14/09/2010,18/09/2013,"Shadow Minister for Regional Development, Local Government and Water"
+"The Hon Barnaby Joyce MP",05/06/2022,,"Shadow Minister for Veterans' Affairs"
 "Senator Belinda Neal",20/03/1996,27/03/1997,"Assistant to the Shadow Minister for Health"
 "Senator Belinda Neal",20/03/1996,27/03/1997,"Shadow Minister for Consumer Affairs"
 "Senator Belinda Neal",27/03/1997,26/08/1997,"Shadow Minister for Consumer Affairs and Local Government"
@@ -500,6 +502,7 @@
 "Senator Marise Payne",06/12/2007,22/09/2008,"Shadow Parliamentary Secretary for Foreign Affairs"
 "Senator Marise Payne",22/09/2008,08/12/2009,"Shadow Parliamentary Secretary for Indigenous Affairs"
 "Senator Marise Payne",22/09/2008,08/12/2009,"Shadow Parliamentary Secretary for International Development Assistance"
+"Senator the Hon Marise Payne",05/06/2022,,"Shadow Cabinet Secretary"
 "Senator Mathias Cormann",14/09/2010,18/09/2013,"Shadow Assistant Treasurer"
 "Senator Mathias Cormann",08/12/2009,14/09/2010,"Shadow Minister for Employment Participation, Apprenticeships and Training"
 "Senator Mathias Cormann",14/09/2010,18/09/2013,"Shadow Minister for Financial Services and Superannuation"
@@ -516,6 +519,8 @@
 "Senator Michaelia Cash",19/09/2012,18/09/2013,"Deputy Manager of Opposition Business in the Senate"
 "Senator Michaelia Cash",14/09/2010,18/09/2013,"Shadow Parliamentary Secretary for Immigration"
 "Senator Michaelia Cash",14/09/2010,18/09/2013,"Shadow Parliamentary Secretary for the Status of Women"
+"Senator the Hon Michaelia Cash",05/06/2022,,"Shadow Minister for Employment and Workplace Relations"
+"Senator the Hon Michaelia Cash",05/06/2022,,"Deputy Leader of the Opposition in the Senate"
 "Senator Mitch Fifield",14/09/2010,18/09/2013,"Manager of Opposition Business in the Senate"
 "Senator Mitch Fifield",14/09/2010,18/09/2013,"Shadow Minister for Disabilities, Carers and the Voluntary Sector"
 "Senator Mitch Fifield",20/02/2009,14/09/2010,"Shadow Parliamentary Secretary for Disabilities, Carers and the Voluntary Sector"
@@ -560,6 +565,8 @@
 "Senator Scott Ryan",14/09/2010,18/09/2013,"Shadow Parliamentary Secretary for Small Business and Fair Competition"
 "Senator Simon Birmingham",14/09/2010,18/09/2013,"Shadow Parliamentary Secretary for the Environment"
 "Senator Simon Birmingham",08/12/2009,18/09/2013,"Shadow Parliamentary Secretary for the Murray Darling Basin"
+"Senator the Hon Simon Birmingham",05/06/2022,,"Shadow Minister for Foreign Affairs"
+"Senator the Hon Simon Birmingham",05/06/2022,,"Leader of the Opposition in the Senate"
 "Senator Stephen Conroy",23/11/2001,06/12/2007,"Deputy Leader of the Opposition in the Senate"
 "Senator Stephen Conroy",30/04/1996,21/10/1998,"Senate Deputy Opposition Whip"
 "Senator Stephen Conroy",26/10/2004,06/12/2007,"Shadow Minister for Communications and Information Technology"
@@ -626,6 +633,8 @@
 "Steven Ciobo",08/12/2009,14/09/2010,"Shadow Minister for Youth and Sport"
 "Stuart Robert",14/09/2010,18/09/2013,"Shadow Minister for Defence Science, Technology and Personnel"
 "Stuart Robert",08/12/2009,14/09/2010,"Shadow Parliamentary Secretary for Defence"
+"The Hon Stuart Robert MP",05/06/2022,,"Shadow Assistant Treasurer"
+"The Hon Stuart Robert MP",05/06/2022,,"Shadow Minister for Financial Services"
 "Sussan Ley",08/12/2009,14/09/2010,"Shadow Assistant Treasurer"
 "Sussan Ley",14/09/2010,18/09/2013,"Shadow Minister for Childcare and Early Childhood Learning"
 "Sussan Ley",14/09/2010,18/09/2013,"Shadow Minister for Employment Participation"
@@ -661,8 +670,13 @@
 "The Hon Kevin Andrews MP",03/03/2011,18/09/2013,"Shadow Minister for Families, Housing and Human Services"
 "The Hon Malcolm Turnbull",03/03/2011,18/09/2013,"Shadow Minister for Communications and Broadband"
 "The Hon Peter Dutton MP",03/03/2011,18/09/2013,"Shadow Minister for Health and Ageing"
+"The Hon Peter Dutton MP",05/06/2022,,"Leader of the Opposition"
 "The Hon Sussan Ley MP",03/03/2011,18/09/2013,"Shadow Minister for Childcare and Early Childhood Learning"
 "The Hon Sussan Ley MP",03/03/2011,18/09/2013,"Shadow Minister for Employment Participation"
+"The Hon Sussan Ley MP",05/06/2022,,"Shadow Minister for Women"
+"The Hon Sussan Ley MP",05/06/2022,,"Shadow Minister for Industry, Skills and Training"
+"The Hon Sussan Ley MP",05/06/2022,,"Deputy Leader of the Opposition"
+"The Hon Sussan Ley MP",05/06/2022,,"Shadow Minister for Small and Family Business"
 "The Hon Teresa Gambaro MP",03/03/2011,18/09/2013,"Shadow Parliamentary Secretary for Citizenship and Settlement"
 "The Hon Teresa Gambaro MP",03/03/2011,18/09/2013,"Shadow Parliamentary Secretary for International Development Assistance"
 "The Hon Warren Truss MP",03/03/2011,18/09/2013,"Leader of The Nationals"
@@ -692,8 +706,8 @@
 "Wayne Swan",26/10/2004,06/12/2007,"Shadow Treasurer"
 Bill Shorten MP,13/10/2013,02/06/2019,Leader of the Opposition
 Bill Shorten MP,06/12/2017,02/06/2019,"Shadow Minister for Indigenous Affairs and Aboriginal and Torres Strait Islanders (House)"
-The Hon Bill Shorten MP,02/06/2019,,"Shadow Minister for the National Disability Insurance Scheme"
-The Hon Bill Shorten MP,02/06/2019,,"Shadow Minister for Government Services"
+The Hon Bill Shorten MP,02/06/2019,01/06/2022,"Shadow Minister for the National Disability Insurance Scheme"
+The Hon Bill Shorten MP,02/06/2019,01/06/2022,"Shadow Minister for Government Services"
 Tanya Plibersek MP,18/10/2013,02/06/2019,Deputy Leader of the Opposition
 Tanya Plibersek MP,18/10/2013,06/12/2017,Shadow Minister for Foreign Affairs and International Development
 The Hon Tanya Plibersek MP,06/12/2017,28/01/2021,Shadow Minister for Education and Training
@@ -701,15 +715,15 @@ Tanya Plibersek MP,06/12/2017,02/06/2019,Shadow Minister for Women
 Tanya Plibersek MP,06/12/2017,02/06/2019,"Shadow Minister for Skills, TAFE and Apprenticeships (House)"
 Tanya Plibersek MP,06/12/2017,02/06/2019,Shadow Minister for Foreign Affairs (House)
 Tanya Plibersek MP,06/12/2017,02/06/2019,Shadow Minister for International Development and the Pacific (House)
-The Hon Tanya Plibersek MP,28/01/2021,,Shadow Minister for Education
-The Hon Tanya Plibersek MP,28/01/2021,,Shadow Minister for Women
-Senator the Hon Penny Wong,18/10/2013,,Leader of the Opposition in the Senate
+The Hon Tanya Plibersek MP,28/01/2021,01/06/2022,Shadow Minister for Education
+The Hon Tanya Plibersek MP,28/01/2021,01/06/2022,Shadow Minister for Women
+Senator the Hon Penny Wong,18/10/2013,01/06/2022,Leader of the Opposition in the Senate
 Senator Penny Wong,18/10/2013,06/12/2017,Shadow Minister for Trade and Investment
-Senator the Hon Penny Wong,06/12/2017,,Shadow Minister for Foreign Affairs
-Senator the Hon Penny Wong,10/11/2020,,Shadow Minister for Defence (Senate)
-Senator the Hon Penny Wong,10/11/2020,,Leader of the Opposition in the Senate
-Senator the Hon Penny Wong,10/11/2020,,Shadow Minister for International Development and the Pacific (Senate)
-Senator the Hon Penny Wong,10/11/2020,,Shadow Minister for Trade (Senate)
+Senator the Hon Penny Wong,06/12/2017,01/06/2022,Shadow Minister for Foreign Affairs
+Senator the Hon Penny Wong,10/11/2020,01/06/2022,Shadow Minister for Defence (Senate)
+Senator the Hon Penny Wong,10/11/2020,01/06/2022,Leader of the Opposition in the Senate
+Senator the Hon Penny Wong,10/11/2020,01/06/2022,Shadow Minister for International Development and the Pacific (Senate)
+Senator the Hon Penny Wong,10/11/2020,01/06/2022,Shadow Minister for Trade (Senate)
 Senator Penny Wong,06/12/2017,21/08/2018,Shadow Attorney-General (Senate)
 Senator Penny Wong,06/12/2017,21/08/2018,Shadow Minister for National Security (Senate)
 Senator Penny Wong,06/12/2017,21/08/2018,Shadow Minister for Justice (Senate)
@@ -720,20 +734,20 @@ Chris Bowen MP,18/10/2013,02/06/2019,Shadow Treasurer
 Chris Bowen MP,06/12/2017,21/08/2018,Acting Shadow Minister for Small Business and Financial Services
 Chris Bowen MP,21/08/2018,02/06/2019,Shadow Minister for Small Business
 The Hon Chris Bowen MP,02/06/2019,28/01/2021,"Shadow Minister for Health"
-The Hon Chris Bowen MP,28/01/2021,,"Shadow Minister for Climate Change and Energy"
+The Hon Chris Bowen MP,28/01/2021,01/06/2022,"Shadow Minister for Climate Change and Energy"
 Tony Burke MP,18/10/2013,06/12/2017,Shadow Minister for Finance
 Tony Burke MP,18/10/2013,02/06/2019,Manager of Opposition Business (House)
 Tony Burke MP,06/12/2017,02/06/2019,Shadow Minister for Environment and Water
 Tony Burke MP,06/12/2017,02/06/2019,Shadow Minister for Citizenship and Multicultural Australia
-The Hon Tony Burke MP,06/12/2017,,Shadow Minister for the Arts
-The Hon Tony Burke MP,02/06/2019,,"Shadow Minister for Industrial Relations"
-The Hon Tony Burke MP,02/06/2019,,"Manager of Opposition Business in the House of Representatives"
-The Hon Mark Dreyfus QC MP,18/10/2013,,Shadow Attorney General
+The Hon Tony Burke MP,06/12/2017,01/06/2022,Shadow Minister for the Arts
+The Hon Tony Burke MP,02/06/2019,01/06/2022,"Shadow Minister for Industrial Relations"
+The Hon Tony Burke MP,02/06/2019,01/06/2022,"Manager of Opposition Business in the House of Representatives"
+The Hon Mark Dreyfus QC MP,18/10/2013,01/06/2022,Shadow Attorney General
 Mark Dreyfus QC MP,18/10/2013,06/12/2017,Shadow Minister for the Arts
 Mark Dreyfus QC MP,18/10/2013,02/06/2019,Deputy Manager of Opposition Business (House)
 Mark Dreyfus QC MP,06/12/2017,02/06/2019,Shadow Minister for National Security
-The Hon Mark Dreyfus QC MP,02/06/2019,,"Shadow Minister for Constitutional Reform"
-The Hon Mark Dreyfus QC MP,10/11/2020,,Shadow Special Minister of State (House)
+The Hon Mark Dreyfus QC MP,02/06/2019,01/06/2022,"Shadow Minister for Constitutional Reform"
+The Hon Mark Dreyfus QC MP,10/11/2020,01/06/2022,Shadow Special Minister of State (House)
 Senator Kim Carr,18/10/2013,06/12/2017,Shadow Minister Assisting the Leader for Science
 Senator Kim Carr,18/10/2013,06/12/2017,"Shadow Minister for Higher Education, Research, Innovation and Industry"
 Senator Kim Carr,06/12/2017,02/06/2019,"Shadow Minister for Innovation, Industry, Science and Research"
@@ -743,16 +757,16 @@ Senator Kim Carr,06/12/2017,02/06/2019,Shadow Minister for Immigration and Borde
 Anthony Albanese MP,18/10/2013,06/12/2017,Shadow Minister for Infrastructure and Transport
 Anthony Albanese MP,18/10/2013,02/06/2019,Shadow Minister for Tourism
 Anthony Albanese MP,06/12/2017,02/06/2019,"Shadow Minister for Infrastructure, Transport, Cities and Regional Development"
-The Hon Anthony Albanese MP,02/06/2019,,"Leader of the Opposition"
+The Hon Anthony Albanese MP,02/06/2019,01/06/2022,"Leader of the Opposition"
 Mark Butler MP,18/10/2013,06/12/2017,"Shadow Minister for Environment, Climate Change and Water"
 The Hon Mark Butler MP,06/12/2017,28/01/2021,Shadow Minister for Climate Change and Energy
-The Hon Mark Butler MP,02/06/2019,,"Deputy Manager of Opposition Business in the House of Representatives"
-The Hon Mark Butler MP,28/01/2021,,"Shadow Minister for Health and Ageing"
+The Hon Mark Butler MP,02/06/2019,01/06/2022,"Deputy Manager of Opposition Business in the House of Representatives"
+The Hon Mark Butler MP,28/01/2021,01/06/2022,"Shadow Minister for Health and Ageing"
 Jason Clare MP,18/10/2013,06/12/2017,Shadow Minister for Communications
 Jason Clare MP,06/12/2017,02/06/2019,Shadow Minister for Resources and Northern Australia
 Jason Clare MP,06/12/2017,02/06/2019,Shadow Minister for Trade and Investment
-The Hon Jason Clare MP,02/06/2019,,"Shadow Minister for Regional Services, Territories and Local Government"
-The Hon Jason Clare MP,02/06/2019,,"Shadow Minister for Housing and Homelessness"
+The Hon Jason Clare MP,02/06/2019,01/06/2022,"Shadow Minister for Regional Services, Territories and Local Government"
+The Hon Jason Clare MP,02/06/2019,01/06/2022,"Shadow Minister for Housing and Homelessness"
 Kate Ellis MP,18/10/2013,06/12/2017,Shadow Minister for Education
 Kate Ellis MP,18/10/2013,06/12/2017,Shadow Minister for Early Childhood
 Joel Fitzgibbon MP,18/10/2013,06/12/2017,Shadow Minister for Agriculture
@@ -764,7 +778,7 @@ Gary Gray AO MP,18/10/2013,06/12/2017,Shadow Minister for Northern Australia
 Gary Gray AO MP,18/10/2013,06/12/2017,Shadow Special Minister of State
 Catherine King MP,18/10/2013,06/12/2017,Shadow Minister for Health
 Catherine King MP,06/12/2017,02/06/2019,Shadow Minister for Health and Medicare
-The Hon Catherine King MP,02/06/2019,,"Shadow Minister for Infrastructure, Transport and Regional Development"
+The Hon Catherine King MP,02/06/2019,01/06/2022,"Shadow Minister for Infrastructure, Transport and Regional Development"
 Jenny Macklin MP,18/10/2013,06/12/2017,Shadow Minister for Families and Payments
 Jenny Macklin MP,18/10/2013,06/12/2017,Shadow Minister for Disability Reform
 Jenny Macklin MP,06/12/2017,21/08/2018,Shadow Minister for Disability and Carers (House)
@@ -772,25 +786,25 @@ Jenny Macklin MP,06/12/2017,21/08/2018,Shadow Minister for Families and Social S
 Jenny Macklin MP,06/12/2017,21/08/2018,Shadow Minister for Housing and Homelessness
 Richard Marles MP,18/10/2013,06/12/2017,Shadow Minister for Immigration and Border Protection
 The Hon Richard Marles MP,06/12/2017,28/01/2021,Shadow Minister for Defence
-The Hon Richard Marles MP,02/06/2019,,"Deputy Leader of the Opposition"
+The Hon Richard Marles MP,02/06/2019,01/06/2022,"Deputy Leader of the Opposition"
 The Hon Richard Marles MP,10/11/2020,28/01/2021,Shadow Minister for Foreign Affairs (House)
 The Hon Richard Marles MP,10/11/2020,28/01/2021,Shadow Minister for Home Affairs (House)
 The Hon Richard Marles MP,10/11/2020,28/01/2021,Shadow Minister for Immigration and Citizenship (House)
-The Hon Richard Marles MP,28/01/2021,,"Shadow Minister for National Reconstruction, Employment, Skills and Small Business"
-The Hon Richard Marles MP,28/01/2021,,"Shadow Minister for Science"
+The Hon Richard Marles MP,28/01/2021,01/06/2022,"Shadow Minister for National Reconstruction, Employment, Skills and Small Business"
+The Hon Richard Marles MP,28/01/2021,01/06/2022,"Shadow Minister for Science"
 Shayne Neumann MP,18/10/2013,06/12/2017,Shadow Minister for Indigenous Affairs
 Shayne Neumann MP,18/10/2013,06/12/2017,Shadow Minister for Ageing
 Shayne Neumann MP,06/12/2017,02/06/2019,Shadow Minister for Immigration and Border Protection
-The Hon Shayne Neumann MP,02/06/2019,,"Shadow Minister for Veterans' Affairs and Defence Personnel"
-The Hon Shayne Neumann MP,10/11/2020,,Shadow Minister for Northern Australia (House)
+The Hon Shayne Neumann MP,02/06/2019,01/06/2022,"Shadow Minister for Veterans' Affairs and Defence Personnel"
+The Hon Shayne Neumann MP,10/11/2020,01/06/2022,Shadow Minister for Northern Australia (House)
 Brendan O’Connor MP,18/10/2013,02/06/2019,Shadow Minister for Employment and Workplace Relations
 The Hon Brendan O’Connor MP,02/06/2019,28/01/2021,"Shadow Minister for Employment and Industry"
 The Hon Brendan O’Connor MP,02/06/2019,28/01/2021,"Shadow Minister for Science"
 The Hon Brendan O’Connor MP,02/06/2019,28/01/2021,"Shadow Minister for Small and Family Business"
-The Hon Brendan O’Connor MP,28/01/2021,,Shadow Minister for Foreign Affairs (House)
-The Hon Brendan O’Connor MP,28/01/2021,,Shadow Minister for Home Affairs (House)
-The Hon Brendan O’Connor MP,28/01/2021,,Shadow Minister for Immigration and Citizenship (House)
-The Hon Brendan O’Connor MP,28/01/2021,,"Shadow Minister for Defence"
+The Hon Brendan O’Connor MP,28/01/2021,01/06/2022,Shadow Minister for Foreign Affairs (House)
+The Hon Brendan O’Connor MP,28/01/2021,01/06/2022,Shadow Minister for Home Affairs (House)
+The Hon Brendan O’Connor MP,28/01/2021,01/06/2022,Shadow Minister for Immigration and Citizenship (House)
+The Hon Brendan O’Connor MP,28/01/2021,01/06/2022,"Shadow Minister for Defence"
 Bernie Ripoll MP,18/10/2013,06/12/2017,Shadow Minister Assisting the Leader for Small Business
 Bernie Ripoll MP,18/10/2013,06/12/2017,Shadow Minister for Financial Services and Superannuation
 Bernie Ripoll MP,18/10/2013,06/12/2017,Shadow Minister for Sport
@@ -806,7 +820,7 @@ Senator Claire Moore,21/08/2018,02/06/2019,Shadow Minister for Preventing Family
 Senator Don Farrell,18/10/2013,06/12/2017,Shadow Minister for the Centenary of ANZAC
 Senator Don Farrell,18/10/2013,06/12/2017,Shadow Minister for Veterans’ Affairs
 Senator Don Farrell,06/12/2017,02/06/2019,Deputy Leader of the Opposition in the Senate
-Senator the Hon Don Farrell,06/12/2017,,Shadow Special Minister of State
+Senator the Hon Don Farrell,06/12/2017,01/06/2022,Shadow Special Minister of State
 Senator the Hon Don Farrell,06/12/2017,28/01/2021,Shadow Minister for Sport
 Senator Don Farrell,06/12/2017,21/08/2018,"Shadow Minister for Infrastructure, Transport, Cities and Regional Development (Senate)"
 Senator Don Farrell,06/12/2017,21/08/2018,"Shadow Minister for Regional Services, Territories and Local Government (Senate)"
@@ -818,12 +832,12 @@ Senator Don Farrell,21/08/2018,02/06/2019,Shadow Attorney-General (Senate)
 Senator Don Farrell,21/08/2018,02/06/2019,Shadow Minister for National Security (Senate)
 Senator Don Farrell,21/08/2018,02/06/2019,Shadow Minister for Justice (Senate)
 Senator the Hon Don Farrell,02/06/2019,28/01/2021,"Shadow Minister for Tourism"
-Senator the Hon Don Farrell,02/06/2019,,"Shadow Minister Assisting the Leader of the Opposition"
-Senator the Hon Don Farrell,10/11/2020,,Shadow Minister for Industrial Relations (Senate)
-Senator the Hon Don Farrell,10/11/2020,,Shadow Minister for the Arts (Senate)
+Senator the Hon Don Farrell,02/06/2019,01/06/2022,"Shadow Minister Assisting the Leader of the Opposition"
+Senator the Hon Don Farrell,10/11/2020,01/06/2022,Shadow Minister for Industrial Relations (Senate)
+Senator the Hon Don Farrell,10/11/2020,01/06/2022,Shadow Minister for the Arts (Senate)
 Senator the Hon Don Farrell,10/11/2020,28/01/2021,Shadow Minister for Small and Family Business (Senate)
 Senator the Hon Don Farrell,10/11/2020,28/01/2021,Shadow Minister Assisting for Small and Family Business (Senate)
-Senator the Hon Don Farrell,28/01/2021,,"Shadow Minister for Sport and Tourism"
+Senator the Hon Don Farrell,28/01/2021,01/06/2022,"Shadow Minister for Sport and Tourism"
 David Feeney MP,18/10/2013,06/12/2017,Shadow Minister for Justice
 David Feeney MP,18/10/2013,06/12/2017,Shadow Assistant Minister for Defence
 Julie Collins MP,18/10/2013,06/12/2017,Shadow Minister for Regional Development and Local Government
@@ -831,19 +845,19 @@ Julie Collins MP,18/10/2013,06/12/2017,Shadow Minister for Employment Services
 Julie Collins MP,06/12/2017,02/06/2019,Shadow Minister for Ageing and Mental Health
 The Hon Julie Collins MP,02/06/2019,28/01/2021,"Shadow Minister for Ageing and Seniors"
 The Hon Julie Collins MP,02/06/2019,28/01/2021,"Shadow Minister for Women"
-The Hon Julie Collins MP,28/01/2021,,"Shadow Minister for Agriculture"
+The Hon Julie Collins MP,28/01/2021,01/06/2022,"Shadow Minister for Agriculture"
 Dr Andrew Leigh MP,18/10/2013,02/06/2019,Shadow Assistant Treasurer
 Dr Andrew Leigh MP,18/10/2013,06/12/2017,Shadow Minister for Competition
 Dr Andrew Leigh MP,06/12/2017,02/06/2019,Shadow Minister for Competition and Productivity
 Dr Andrew Leigh MP,06/12/2017,02/06/2019,Shadow Minister for Charities and Not-for-Profits
 Dr Andrew Leigh MP,06/12/2017,02/06/2019,"Shadow Minister for Innovation, Industry, Science and Research (House)"
 Dr Andrew Leigh MP,06/12/2017,02/06/2019,Shadow Minister for Trade in Services
-The Hon Dr Andrew Leigh MP,02/06/2019,,"Shadow Assistant Minister for Treasury"
-The Hon Dr Andrew Leigh MP,02/06/2019,,"Shadow Assistant Minister for Charities"
+The Hon Dr Andrew Leigh MP,02/06/2019,01/06/2022,"Shadow Assistant Minister for Treasury"
+The Hon Dr Andrew Leigh MP,02/06/2019,01/06/2022,"Shadow Assistant Minister for Charities"
 Sharon Bird MP,18/10/2013,06/12/2017,Shadow Minister for Vocational Education
 Michelle Rowland MP,18/10/2013,06/12/2017,Shadow Assistant Minister for Communications
 Michelle Rowland MP,18/10/2013,06/12/2017,Shadow Minister for Citizenship and Multiculturalism
-Michelle Rowland MP,06/12/2017,,Shadow Minister for Communications
+Michelle Rowland MP,06/12/2017,01/06/2022,Shadow Minister for Communications
 Melissa Parke MP,18/10/2013,06/12/2017,Shadow Assistant Minister for Health
 Senator Jan McLucas,18/10/2013,06/12/2017,Shadow Minister for Mental Health
 Senator Jan McLucas,18/10/2013,06/12/2017,Shadow Minister for Housing and Homelessness
@@ -881,38 +895,38 @@ Dr Jim Chalmers MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Trad
 Dr Jim Chalmers MP,06/12/2017,02/06/2019,Shadow Special Minister of State (House)
 Dr Jim Chalmers MP,06/12/2017,02/06/2019,Shadow Minister for Sport (House)
 Dr Jim Chalmers MP,06/12/2017,02/06/2019,Shadow Minister for Finance
-Dr Jim Chalmers MP,02/06/2019,,Shadow Treasurer
-Dr Jim Chalmers MP,10/11/2020,,Shadow Minister for Finance (House)
-Dr Jim Chalmers MP,10/11/2020,,Shadow Minister for the Public Service (House)
+Dr Jim Chalmers MP,02/06/2019,01/06/2022,Shadow Treasurer
+Dr Jim Chalmers MP,10/11/2020,01/06/2022,Shadow Minister for Finance (House)
+Dr Jim Chalmers MP,10/11/2020,01/06/2022,Shadow Minister for the Public Service (House)
 Matt Thistlethwaite MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Foreign Affairs
 Matt Thistlethwaite MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Immigration
 Matt Thistlethwaite MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Treasury
 Matt Thistlethwaite MP,06/12/2017,02/06/2019,Shadow Assistant Minister for an Australian Head of State
 The Hon Matt Thistlethwaite MP,02/06/2019,28/01/2021,"Shadow Assistant Minister for Financial Services"
-The Hon Matt Thistlethwaite MP,02/06/2019,,"Shadow Assistant Minister for the Republic"
-The Hon Matt Thistlethwaite MP,28/01/2021,,"Shadow Assistant Minister for Financial Services and Superannuation"
+The Hon Matt Thistlethwaite MP,02/06/2019,01/06/2022,"Shadow Assistant Minister for the Republic"
+The Hon Matt Thistlethwaite MP,28/01/2021,01/06/2022,"Shadow Assistant Minister for Financial Services and Superannuation"
 Gai Brodtmann MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Defence
 Gai Brodtmann MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Cyber Security and Defence
 Stephen Jones MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Regional Development and Infrastructure
 Stephen Jones MP,06/12/2017,02/06/2019,"Shadow Minister for Regional Services, Territories and Local Government"
 Stephen Jones MP,06/12/2017,02/06/2019,Shadow Minister for Regional Communications
-Stephen Jones MP,02/06/2019,,"Shadow Assistant Treasurer"
+Stephen Jones MP,02/06/2019,01/06/2022,"Shadow Assistant Treasurer"
 Stephen Jones MP,02/06/2019,28/01/2021,"Shadow Minister for Financial Services"
-Stephen Jones MP,28/01/2021,,"Shadow Minister for Financial Services and Superannuation"
+Stephen Jones MP,28/01/2021,01/06/2022,"Shadow Minister for Financial Services and Superannuation"
 Warren Snowdon MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for External Territories
 Warren Snowdon MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Northern Australia
 Warren Snowdon MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Indigenous Affairs
-The Hon Warren Snowdon MP,06/12/2017,,Shadow Assistant Minister for External Territories
+The Hon Warren Snowdon MP,06/12/2017,01/06/2022,Shadow Assistant Minister for External Territories
 Warren Snowdon MP,06/12/2017,02/06/2019,Shadow Assistant Minister for the Centenary of ANZAC
 Warren Snowdon MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Indigenous Health
-The Hon Warren Snowdon MP,06/12/2017,,Shadow Assistant Minister for Northern Australia
-The Hon Warren Snowdon MP,02/06/2019,,"Shadow Assistant Minister for Indigenous Australians"
+The Hon Warren Snowdon MP,06/12/2017,01/06/2022,Shadow Assistant Minister for Northern Australia
+The Hon Warren Snowdon MP,02/06/2019,01/06/2022,"Shadow Assistant Minister for Indigenous Australians"
 Ed Husic MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary to the Shadow Treasurer
 Ed Husic MP,06/12/2017,02/06/2019,Shadow Minister for the Digital Economy
 Ed Husic MP,06/12/2017,21/08/2018,"Shadow Minister for Employment Services, Workforce Participation and Future of Work"
 Ed Husic MP,21/08/2018,02/06/2019,Shadow Minister for Human Services
 The Hon Ed Husic MP,10/11/2020,28/01/2021,"Shadow Minister for Agriculture and Resources"
-The Hon Ed Husic MP,28/01/2021,,"Shadow Minister for Industry and Innovation"
+The Hon Ed Husic MP,28/01/2021,01/06/2022,"Shadow Minister for Industry and Innovation"
 Senator Louise Pratt,18/10/2013,06/12/2017,"Shadow Parliamentary Secretary for the Environment, Climate Change and Water"
 Senator Louise Pratt,06/12/2017,02/06/2019,Shadow Minister for Environment and Water (Senate)
 Senator Louise Pratt,06/12/2017,21/08/2018,Shadow Assistant Minister for Families and Communities
@@ -921,13 +935,13 @@ Senator Louise Pratt,21/08/2018,02/06/2019,Shadow Assistant Minister for Univers
 Senator Louise Pratt,21/08/2018,02/06/2019,Shadow Assistant Minister for Equality
 Senator Louise Pratt,18/02/2019,02/06/2019,Shadow Minister for Citizenship and Multicultural Australia (Senate)
 Senator Louise Pratt,18/02/2019,02/06/2019,Shadow Minister for the Arts (Senate)
-Senator Louise Pratt,02/06/2019,,"Shadow Assistant Minister for Manufacturing"
+Senator Louise Pratt,02/06/2019,01/06/2022,"Shadow Assistant Minister for Manufacturing"
 Senator Louise Pratt,10/11/2020,28/01/2021,"Shadow Assistant Minister for Employment Services"
 Senator Louise Pratt,10/11/2020,28/01/2021,Shadow Minister for Employment and Industry (Senate)
 Senator Louise Pratt,10/11/2020,28/01/2021,Shadow Minister for Science (Senate)
 Senator Louise Pratt,10/11/2020,28/01/2021,Shadow Minister for Innovation, Technology and the Future of Work (Senate)
-Senator Louise Pratt,28/01/2021,,"Shadow Assistant Minister for Employment and Skills"
-Senator Louise Pratt,28/01/2021,,Shadow Minister for Communications (Senate)
+Senator Louise Pratt,28/01/2021,01/06/2022,"Shadow Assistant Minister for Employment and Skills"
+Senator Louise Pratt,28/01/2021,01/06/2022,Shadow Minister for Communications (Senate)
 Tony Zappia MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Manufacturing
 Tony Zappia MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Medicare
 Senator Lisa Singh,18/10/2013,06/12/2017,Shadow Parliamentary Secretary to the Shadow Attorney General
@@ -935,21 +949,21 @@ Amanda Rishworth MP,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Hea
 Amanda Rishworth MP,06/12/2017,02/06/2019,Shadow Minister for Veterans' Affairs
 Amanda Rishworth MP,06/12/2017,02/06/2019,Shadow Minister for Defence Personnel
 Amanda Rishworth MP,06/12/2017,02/06/2019,Shadow Minister for Early Childhood Education and Development
-The Hon Amanda Rishworth MP,02/06/2019,,"Shadow Minister for Early Childhood Education"
-The Hon Amanda Rishworth MP,02/06/2019,,"Shadow Minister for Youth"
+The Hon Amanda Rishworth MP,02/06/2019,01/06/2022,"Shadow Minister for Early Childhood Education"
+The Hon Amanda Rishworth MP,02/06/2019,01/06/2022,"Shadow Minister for Youth"
 The Hon Amanda Rishworth MP,10/11/2020,28/01/2021,Shadow Minister for Tourism (House)
-The Hon Amanda Rishworth MP,28/01/2021,,Shadow Minister for Sport and Tourism (House)
+The Hon Amanda Rishworth MP,28/01/2021,01/06/2022,Shadow Minister for Sport and Tourism (House)
 Senator Carol Brown,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Families and Payments
 Senator Carol Brown,06/12/2017,02/06/2019,Shadow Minister for Disability and Carers
 Senator Carol Brown,06/12/2017,02/06/2019,Shadow Minister for Tourism (Senate)
 Senator Carol Brown,06/12/2017,02/06/2019,"Shadow Minister for Agriculture, Fisheries and Forestry (Senate)"
 Senator Carol Brown,06/12/2017,02/06/2019,Shadow Minister for Rural and Regional Australia (Senate)
-Senator Carol Brown,02/06/2019,,"Shadow Assistant Minister for Infrastructure and Regional Tourism"
-Senator Carol Brown,02/06/2019,,"Shadow Assistant Minister for Tasmania"
+Senator Carol Brown,02/06/2019,01/06/2022,"Shadow Assistant Minister for Infrastructure and Regional Tourism"
+Senator Carol Brown,02/06/2019,01/06/2022,"Shadow Assistant Minister for Tasmania"
 Senator Carol Brown,10/11/2020,28/01/2021,Shadow Minister for the National Disability Insurance Scheme (Senate)
 Senator Carol Brown,10/11/2020,28/01/2021,Shadow Minister for Government Services (Senate)
-Senator Carol Brown,28/01/2021,,Shadow Minister for Regional Services, Territories and Local Government (Senate)
-Senator Carol Brown,28/01/2021,,Shadow Minister for Housing and Homelessness (Senate)
+Senator Carol Brown,28/01/2021,01/06/2022,Shadow Minister for Regional Services, Territories and Local Government (Senate)
+Senator Carol Brown,28/01/2021,01/06/2022,Shadow Minister for Housing and Homelessness (Senate)
 Senator Helen Polley,18/10/2013,06/12/2017,Shadow Parliamentary Secretary for Aged Care
 Senator Helen Polley,06/12/2017,02/06/2019,"Shadow Assistant Minister to the Leader (Tasmania)"
 Senator Helen Polley,06/12/2017,02/06/2019,Shadow Minister for Health and Medicare (Senate)
@@ -958,42 +972,42 @@ Senator Helen Polley,06/12/2017,02/06/2019,Shadow Assistant Minister for Ageing
 Senator Patrick Dodson,06/12/2017,02/06/2019,"Shadow Minister for Indigenous Affairs and Aboriginal and Torres Strait Islanders (Senate)"
 Senator Patrick Dodson,06/12/2017,02/06/2019,"Shadow Assistant Minister for Indigenous Affairs and Aboriginal and Torres Strait Islanders"
 Senator Patrick Dodson,06/12/2017,02/06/2019,Shadow Minister for Regional Communications (Senate)
-Senator Patrick Dodson,02/06/2019,,"Shadow Assistant Minister for Reconciliation"
-Senator Patrick Dodson,02/06/2019,,"Shadow Assistant Minister for Constitutional Recognition of Indigenous Australians"
-Senator Patrick Dodson,10/11/2020,,Shadow Minister for Families and Social Services (Senate)
-Senator Patrick Dodson,10/11/2020,,Shadow Minister for Indigenous Australians (Senate)
-Senator Patrick Dodson,10/11/2020,,Shadow Minister for Constitutional Reform (Senate)
+Senator Patrick Dodson,02/06/2019,01/06/2022,"Shadow Assistant Minister for Reconciliation"
+Senator Patrick Dodson,02/06/2019,01/06/2022,"Shadow Assistant Minister for Constitutional Recognition of Indigenous Australians"
+Senator Patrick Dodson,10/11/2020,01/06/2022,Shadow Minister for Families and Social Services (Senate)
+Senator Patrick Dodson,10/11/2020,01/06/2022,Shadow Minister for Indigenous Australians (Senate)
+Senator Patrick Dodson,10/11/2020,01/06/2022,Shadow Minister for Constitutional Reform (Senate)
 Terri Butler MP,06/12/2017,21/08/2018,"Shadow Assistant Minister for Preventing Family Violence"
 Terri Butler MP,06/12/2017,21/08/2018,"Shadow Assistant Minister for Universities"
 Terri Butler MP,06/12/2017,21/08/2018,"Shadow Assistant Minister for Equality"
 Terri Butler MP,21/08/2018,02/06/2019,Shadow Minister for Young Australians and Youth Affairs
 Terri Butler MP,21/08/2018,02/06/2019,"Shadow Minister for Employment Services, Workforce Participation and Future of Work"
-Terri Butler MP,02/06/2019,,"Shadow Minister for the Environment and Water"
+Terri Butler MP,02/06/2019,01/06/2022,"Shadow Minister for the Environment and Water"
 Andrew Giles MP,06/12/2017,02/06/2019,"Shadow Assistant Minister for Schools"
-Andrew Giles MP,02/06/2019,,"Shadow Minister for Cities and Urban Infrastructure"
-Andrew Giles MP,02/06/2019,,"Shadow Minister for Multicultural Affairs"
-Andrew Giles MP,02/06/2019,,"Shadow Minister Assisting for Immigration and Citizenship"
-Andrew Giles MP,10/11/2020,,Shadow Minister for Disaster and Emergency Management (House)
+Andrew Giles MP,02/06/2019,01/06/2022,"Shadow Minister for Cities and Urban Infrastructure"
+Andrew Giles MP,02/06/2019,01/06/2022,"Shadow Minister for Multicultural Affairs"
+Andrew Giles MP,02/06/2019,01/06/2022,"Shadow Minister Assisting for Immigration and Citizenship"
+Andrew Giles MP,10/11/2020,01/06/2022,Shadow Minister for Disaster and Emergency Management (House)
 Tim Hammond MP,06/12/2017,21/08/2018,Shadow Minister for Consumer Affairs
 Tim Hammond MP,06/12/2017,21/08/2018,Shadow Minister Assisting for Resources
 Linda Burney MP,06/12/2017,21/08/2018,Shadow Minister for Human Services
 Linda Burney MP,21/08/2018,02/06/2019,Shadow Minister for Preventing Family Violence
-The Hon Linda Burney MP,21/08/2018,,Shadow Minister for Families and Social Services
+The Hon Linda Burney MP,21/08/2018,01/06/2022,Shadow Minister for Families and Social Services
 Linda Burney MP,21/08/2018,02/06/2019,Shadow Minister for Housing and Homelessness (House)
 Linda Burney MP,21/08/2018,02/06/2019,Shadow Minister for Disability and Carers (House)
-The Hon Linda Burney MP,02/06/2019,,"Shadow Minister for Indigenous Australians"
+The Hon Linda Burney MP,02/06/2019,01/06/2022,"Shadow Minister for Indigenous Australians"
 Pat Conroy MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Infrastructure
 Pat Conroy MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Climate Change and Energy
-Pat Conroy MP,02/06/2019,,"Shadow Minister for International Development and the Pacific"
-Pat Conroy MP,02/06/2019,,"Shadow Minister Assisting for Climate Change"
-Pat Conroy MP,02/06/2019,,"Shadow Minister Assisting for Defence"
+Pat Conroy MP,02/06/2019,01/06/2022,"Shadow Minister for International Development and the Pacific"
+Pat Conroy MP,02/06/2019,01/06/2022,"Shadow Minister Assisting for Climate Change"
+Pat Conroy MP,02/06/2019,01/06/2022,"Shadow Minister Assisting for Defence"
 Pat Conroy MP,10/11/2020,28/01/2021,Shadow Minister for Sport (House)
-Pat Conroy MP,28/01/2021,,"Shadow Minister Assisting on Government Accountability"
-Pat Conroy MP,28/01/2021,,Shadow Minister for Government Accountability (House)
+Pat Conroy MP,28/01/2021,01/06/2022,"Shadow Minister Assisting on Government Accountability"
+Pat Conroy MP,28/01/2021,01/06/2022,Shadow Minister for Government Accountability (House)
 Clare O'Neil MP,06/12/2017,02/06/2019,Shadow Minister for Justice
 Clare O'Neil MP,21/08/2018,02/06/2019,Shadow Minister for Financial Services
 Clare O'Neil MP,02/06/2019,28/01/2021,"Shadow Minister for Innovation, Technology and the Future of Work"
-Clare O'Neil MP,28/01/2021,,"Shadow Minister for Senior Australians and Aged Care Services"
+Clare O'Neil MP,28/01/2021,01/06/2022,"Shadow Minister for Senior Australians and Aged Care Services"
 Lisa Chesters MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Workplace Relations
 Lisa Chesters MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Rural and Regional Australia
 Mike Kelly AM MP,06/12/2017,02/06/2019,Shadow Assistant Minister for Defence Industry and Support
@@ -1012,83 +1026,143 @@ Senator Deborah O'Neill,18/02/2019,02/06/2019,Shadow Minister for Early Childhoo
 Madeleine King MP,21/08/2018,02/06/2019,Shadow Minister for Consumer Affairs
 Madeleine King MP,21/08/2018,02/06/2019,Shadow Minister Assisting for Small Business
 Madeleine King MP,21/08/2018,02/06/2019,Shadow Minister Assisting for Resources
-Madeleine King MP,02/06/2019,,"Shadow Minister for Trade"
-Madeleine King MP,28/01/2021,,"Shadow Minister for Resources"
-Madeleine King MP,28/01/2021,,Shadow Minister for Queensland Resources (House)
+Madeleine King MP,02/06/2019,01/06/2022,"Shadow Minister for Trade"
+Madeleine King MP,28/01/2021,01/06/2022,"Shadow Minister for Resources"
+Madeleine King MP,28/01/2021,01/06/2022,Shadow Minister for Queensland Resources (House)
 Senator Jenny McAllister,21/08/2018,02/06/2019,Shadow Assistant Minister for Families and Communities
 Senator Jenny McAllister,21/08/2018,02/06/2019,Shadow Minister for Climate Change and Energy
-Senator Jenny McAllister,02/06/2019,,"Shadow Cabinet Secretary"
-Senator Jenny McAllister,02/06/2019,,"Shadow Assistant Minister to the Leader of the Opposition in the Senate"
-Senator Jenny McAllister,10/11/2020,,Shadow Assistant Treasurer (Senate)
+Senator Jenny McAllister,02/06/2019,01/06/2022,"Shadow Cabinet Secretary"
+Senator Jenny McAllister,02/06/2019,01/06/2022,"Shadow Assistant Minister to the Leader of the Opposition in the Senate"
+Senator Jenny McAllister,10/11/2020,01/06/2022,Shadow Assistant Treasurer (Senate)
 Senator Jenny McAllister,10/11/2020,28/01/2021,Shadow Minister for Financial Services (Senate)
-Senator Jenny McAllister,10/11/2020,,Shadow Minister for Climate Change and Energy (Senate)
-Senator Jenny McAllister,10/11/2020,,Shadow Minister Assisting for Climate Change (Senate)
-Senator Jenny McAllister,10/11/2020,,"Shadow Assistant Minister for Communities and the Prevention of Family Violence"
-Senator Jenny McAllister,10/11/2020,,Shadow Minister for Women (Senate)
-Senator Jenny McAllister,10/11/2020,,Shadow Minister for the Environment and Water (Senate)
-Senator Jenny McAllister,28/01/2021,,Shadow Minister for Financial Services and Superannuation (Senate)
+Senator Jenny McAllister,10/11/2020,01/06/2022,Shadow Minister for Climate Change and Energy (Senate)
+Senator Jenny McAllister,10/11/2020,01/06/2022,Shadow Minister Assisting for Climate Change (Senate)
+Senator Jenny McAllister,10/11/2020,01/06/2022,"Shadow Assistant Minister for Communities and the Prevention of Family Violence"
+Senator Jenny McAllister,10/11/2020,01/06/2022,Shadow Minister for Women (Senate)
+Senator Jenny McAllister,10/11/2020,01/06/2022,Shadow Minister for the Environment and Water (Senate)
+Senator Jenny McAllister,28/01/2021,01/06/2022,Shadow Minister for Financial Services and Superannuation (Senate)
 Senator Glenn Sterle,21/08/2018,02/06/2019,"Shadow Minister for Infrastructure, Transport, Cities and Regional Development (Senate)"
 Senator Glenn Sterle,21/08/2018,02/06/2019,"Shadow Minister for Regional Services, Territories and Local Government (Senate)"
-Senator Glenn Sterle,21/08/2018,,Shadow Assistant Minister for Road Safety
+Senator Glenn Sterle,21/08/2018,01/06/2022,Shadow Assistant Minister for Road Safety
 Senator Glenn Sterle,10/11/2020,28/01/2021,Shadow Minister for Agriculture and Resources (Senate)
 Senator Glenn Sterle,10/11/2020,28/01/2021,Shadow Minister for Western Australian Resources (Senate)
-Senator Glenn Sterle,28/01/2021,,Shadow Minister for Agriculture (Senate)
-Senator the Hon Kristina Keneally,02/06/2019,,"Deputy Leader of the Opposition in the Senate"
-Senator the Hon Kristina Keneally,02/06/2019,,"Shadow Minister for Home Affairs"
-Senator the Hon Kristina Keneally,02/06/2019,,"Shadow Minister for Immigration and Citizenship"
-Senator the Hon Kristina Keneally,10/11/2020,,Shadow Minister for Multicultural Affairs (Senate)
-Senator the Hon Kristina Keneally,10/11/2020,,Shadow Minister Assisting for Immigration and Citizenship (Senate)
+Senator Glenn Sterle,28/01/2021,01/06/2022,Shadow Minister for Agriculture (Senate)
+Senator the Hon Kristina Keneally,02/06/2019,01/06/2022,"Deputy Leader of the Opposition in the Senate"
+Senator the Hon Kristina Keneally,02/06/2019,01/06/2022,"Shadow Minister for Home Affairs"
+Senator the Hon Kristina Keneally,02/06/2019,01/06/2022,"Shadow Minister for Immigration and Citizenship"
+Senator the Hon Kristina Keneally,10/11/2020,01/06/2022,Shadow Minister for Multicultural Affairs (Senate)
+Senator the Hon Kristina Keneally,10/11/2020,01/06/2022,Shadow Minister Assisting for Immigration and Citizenship (Senate)
 Senator the Hon Kristina Keneally,10/11/2020,28/01/2021,Shadow Minister for Education and Training (Senate)
 Senator the Hon Kristina Keneally,10/11/2020,28/01/2021,Shadow Minister for Ageing and Seniors (Senate)
-Senator the Hon Kristina Keneally,10/11/2020,,Shadow Minister for Early Childhood Education (Senate)
-Senator the Hon Kristina Keneally,10/11/2020,,Shadow Minister for Youth (Senate)
-Senator the Hon Kristina Keneally,28/01/2021,,Shadow Minister for Education (Senate)
-Senator the Hon Kristina Keneally,28/01/2021,,Shadow Minister for National Reconstruction, Employment, Skills and Small Business (Senate)
-Senator the Hon Kristina Keneally,28/01/2021,,Shadow Minister Assisting for Small Business (Senate)
-Senator the Hon Kristina Keneally,28/01/2021,,"Shadow Minister for Government Accountability"
-Senator the Hon Kristina Keneally,28/01/2021,,Shadow Minister Assisting on Government Accountability (Senate)
-Senator Katy Gallagher,01/07/2019,,"Shadow Minister for Finance"
-Senator Katy Gallagher,01/07/2019,,"Shadow Minister for the Public Service"
-Senator Katy Gallagher,01/07/2019,,"Manager of Opposition Business in the Senate"
-Senator Katy Gallagher,10/11/2020,,Shadow Treasurer (Senate)
-Matt Keogh MP,02/06/2019,,"Shadow Minister for Defence Industry"
+Senator the Hon Kristina Keneally,10/11/2020,01/06/2022,Shadow Minister for Early Childhood Education (Senate)
+Senator the Hon Kristina Keneally,10/11/2020,01/06/2022,Shadow Minister for Youth (Senate)
+Senator the Hon Kristina Keneally,28/01/2021,01/06/2022,Shadow Minister for Education (Senate)
+Senator the Hon Kristina Keneally,28/01/2021,01/06/2022,Shadow Minister for National Reconstruction, Employment, Skills and Small Business (Senate)
+Senator the Hon Kristina Keneally,28/01/2021,01/06/2022,Shadow Minister Assisting for Small Business (Senate)
+Senator the Hon Kristina Keneally,28/01/2021,01/06/2022,"Shadow Minister for Government Accountability"
+Senator the Hon Kristina Keneally,28/01/2021,01/06/2022,Shadow Minister Assisting on Government Accountability (Senate)
+Senator Katy Gallagher,01/07/2019,01/06/2022,"Shadow Minister for Finance"
+Senator Katy Gallagher,01/07/2019,01/06/2022,"Shadow Minister for the Public Service"
+Senator Katy Gallagher,01/07/2019,01/06/2022,"Manager of Opposition Business in the Senate"
+Senator Katy Gallagher,10/11/2020,01/06/2022,Shadow Treasurer (Senate)
+Matt Keogh MP,02/06/2019,01/06/2022,"Shadow Minister for Defence Industry"
 Matt Keogh MP,02/06/2019,28/01/2021,"Shadow Minister for Western Australian Resources"
 Matt Keogh MP,02/06/2019,28/01/2021,"Shadow Minister Assisting for Small and Family Business"
-Matt Keogh MP,28/01/2021,,"Shadow Minister Assisting for Small Business"
-Senator Murray Watt,02/06/2019,,"Shadow Minister for Northern Australia"
+Matt Keogh MP,28/01/2021,01/06/2022,"Shadow Minister Assisting for Small Business"
+Senator Murray Watt,02/06/2019,01/06/2022,"Shadow Minister for Northern Australia"
 Senator Murray Watt,02/06/2019,28/01/2021,"Shadow Minister for Natural Disaster and Emergency Management"
 Senator Murray Watt,10/11/2020,28/01/2021,Shadow Minister for Health (Senate)
-Senator Murray Watt,10/11/2020,,Shadow Minister for Infrastructure, Transport and Regional Development (Senate)
-Senator Murray Watt,10/11/2020,,Shadow Minister for Cities and Urban Infrastructure (Senate)
-Senator Murray Watt,10/11/2020,,Shadow Attorney-General (Senate)
+Senator Murray Watt,10/11/2020,01/06/2022,Shadow Minister for Infrastructure, Transport and Regional Development (Senate)
+Senator Murray Watt,10/11/2020,01/06/2022,Shadow Minister for Cities and Urban Infrastructure (Senate)
+Senator Murray Watt,10/11/2020,01/06/2022,Shadow Attorney-General (Senate)
 Senator Murray Watt,10/11/2020,28/01/2021,Shadow Minister for Regional Services, Territories and Local Government (Senate)
 Senator Murray Watt,10/11/2020,28/01/2021,Shadow Minister for Housing and Homelessness (Senate)
-Senator Murray Watt,28/01/2021,,"Shadow Minister for Disaster and Emergency Management"
-Senator Murray Watt,28/01/2021,,"Shadow Minister for Queensland Resources"
-Senator Murray Watt,28/01/2021,,Shadow Minister for Resources (Senate)
-Senator Murray Watt,28/01/2021,,Shadow Minister for Health and Ageing (Senate)
-Senator Murray Watt,28/01/2021,,Shadow Minister for Senior Australians and Aged Care Services (Senate)
-Senator Murray Watt,28/01/2021,,Shadow Minister for Science (Senate)
-Senator Murray Watt,28/01/2021,,Shadow Minister for Industry and Innovation (Senate)
+Senator Murray Watt,28/01/2021,01/06/2022,"Shadow Minister for Disaster and Emergency Management"
+Senator Murray Watt,28/01/2021,01/06/2022,"Shadow Minister for Queensland Resources"
+Senator Murray Watt,28/01/2021,01/06/2022,Shadow Minister for Resources (Senate)
+Senator Murray Watt,28/01/2021,01/06/2022,Shadow Minister for Health and Ageing (Senate)
+Senator Murray Watt,28/01/2021,01/06/2022,Shadow Minister for Senior Australians and Aged Care Services (Senate)
+Senator Murray Watt,28/01/2021,01/06/2022,Shadow Minister for Science (Senate)
+Senator Murray Watt,28/01/2021,01/06/2022,Shadow Minister for Industry and Innovation (Senate)
 Graham Perrett MP,02/06/2019,28/01/2021,"Shadow Assistant Minister for Education and Training"
-Graham Perrett MP,28/01/2021,,"Shadow Assistant Minister for Education"
-Emma McBride MP,02/06/2019,,"Shadow Assistant Minister for Mental Health"
-Emma McBride MP,02/06/2019,,"Shadow Assistant Minister for Carers"
+Graham Perrett MP,28/01/2021,01/06/2022,"Shadow Assistant Minister for Education"
+Emma McBride MP,02/06/2019,01/06/2022,"Shadow Assistant Minister for Mental Health"
+Emma McBride MP,02/06/2019,01/06/2022,"Shadow Assistant Minister for Carers"
 Ged Kearney MP,02/06/2019,28/01/2021,"Shadow Assistant Minister for Skills"
 Ged Kearney MP,02/06/2019,28/01/2021,"Shadow Assistant Minister for Aged Care"
-Ged Kearney MP,28/01/2021,,"Shadow Assistant Minister for Health and Ageing"
-Josh Wilson MP,02/06/2019,,"Shadow Assistant Minister for the Environment"
+Ged Kearney MP,28/01/2021,01/06/2022,"Shadow Assistant Minister for Health and Ageing"
+Josh Wilson MP,02/06/2019,01/06/2022,"Shadow Assistant Minister for the Environment"
 Senator Kimberley Kitching,02/06/2019,28/01/2021,"Shadow Assistant Minister for Government Accountability"
-Senator Kimberley Kitching,02/06/2019,,"Deputy Manager of Opposition Business in the Senate"
-Senator Kimberley Kitching,10/11/2020,,Shadow Minister for Veterans' Affairs and Defence Personnel (Senate)
-Senator Kimberley Kitching,10/11/2020,,Shadow Minister Assisting for Defence (Senate)
-Senator Kimberley Kitching,10/11/2020,,Shadow Minister for Defence Industry (Senate)
+Senator Kimberley Kitching,02/06/2019,01/06/2022,"Deputy Manager of Opposition Business in the Senate"
+Senator Kimberley Kitching,10/11/2020,01/06/2022,Shadow Minister for Veterans' Affairs and Defence Personnel (Senate)
+Senator Kimberley Kitching,10/11/2020,01/06/2022,Shadow Minister Assisting for Defence (Senate)
+Senator Kimberley Kitching,10/11/2020,01/06/2022,Shadow Minister for Defence Industry (Senate)
 Senator Kimberley Kitching,10/11/2020,28/01/2021,Shadow Minister for Communications (Senate)
-Senator Kimberley Kitching,28/01/2021,,Shadow Minister for the National Disability Insurance Scheme (Senate)
-Senator Kimberley Kitching,28/01/2021,,Shadow Minister for Government Services (Senate)
-Senator Kimberley Kitching,28/01/2021,,"Shadow Assistant Minister for Government Services and the NDIS"
+Senator Kimberley Kitching,28/01/2021,01/06/2022,Shadow Minister for the National Disability Insurance Scheme (Senate)
+Senator Kimberley Kitching,28/01/2021,01/06/2022,Shadow Minister for Government Services (Senate)
+Senator Kimberley Kitching,28/01/2021,01/06/2022,"Shadow Assistant Minister for Government Services and the NDIS"
 Tim Watts MP,02/06/2019,28/01/2021,"Shadow Assistant Minister for Communications"
 Tim Watts MP,02/06/2019,28/01/2021,"Shadow Assistant Minister for Cyber Security"
-Tim Watts MP,28/01/2021,,"Shadow Assistant Minister for Communications and Cyber Security"
-Meryl Swanson MP,10/11/2020,,"Shadow Assistant Minister for Defence"
-Patrick Gorman MP,28/01/2021,,"Shadow Assistant Minister for Western Australia"
+Tim Watts MP,28/01/2021,01/06/2022,"Shadow Assistant Minister for Communications and Cyber Security"
+Meryl Swanson MP,10/11/2020,01/06/2022,"Shadow Assistant Minister for Defence"
+Patrick Gorman MP,28/01/2021,01/06/2022,"Shadow Assistant Minister for Western Australia"
+Senator the Hon Jane Hume,05/06/2022,,"Shadow Minister for the Public Service"
+Senator the Hon Jane Hume,05/06/2022,,"Shadow Minister for Finance"
+Senator the Hon Jane Hume,05/06/2022,,"Shadow Special Minister of State"
+Julian Leeser MP,05/06/2022,,"Shadow Minister for Indigenous Australians"
+Julian Leeser MP,05/06/2022,,"Shadow Attorney-General"
+Senator the Hon James McGrath,05/06/2022,,"Shadow Assistant Minister to the Leader of the Opposition"
+Senator the Hon James McGrath,05/06/2022,,"Shadow Assistant Minister for Finance"
+Senator Susan McDonald,05/06/2022,,"Shadow Minister for Resources"
+Senator Susan McDonald,05/06/2022,,"Shadow Minister for Northern Australia"
+Ted O'Brien MP,05/06/2022,,"Shadow Minister for Climate Change and Energy"
+The Hon Michelle Landry MP,05/06/2022,,"Shadow Assistant Minister for Manufacturing"
+Senator Hollie Hughes,05/06/2022,,"Shadow Assistant Minister for Climate Change and Energy"
+The Hon David Littleproud MP,05/06/2022,,"Shadow Minister for Agriculture"
+The Hon David Littleproud MP,05/06/2022,,"Leader of the Nationals"
+Senator Perin Davey,05/06/2022,,"Shadow Minister for Water"
+Senator Perin Davey,05/06/2022,,"Deputy Leader of the Nationals"
+Senator Perin Davey,05/06/2022,,"Shadow Minister for Emergency Management"
+Senator the Hon Jonathan Duniam,05/06/2022,,"Shadow Minister for Environment, Fisheries and Forestry"
+The Hon Kevin Hogan MP,05/06/2022,,"Shadow Minister for Trade and Tourism"
+The Hon Kevin Hogan MP,05/06/2022,,"Deputy Manager of Opposition Business in the House"
+The Hon Michael McCormack MP,05/06/2022,,"Shadow Minister for International Development and the Pacific"
+Rick Wilson MP,05/06/2022,,"Shadow Assistant Minister for Trade"
+Senator Claire Chandler,05/06/2022,,"Shadow Assistant Minister for Foreign Affairs"
+The Hon Alan Tudge MP,05/06/2022,,"Shadow Minister for Education"
+The Hon Andrew Gee MP,05/06/2022,,"Shadow Minister for Regional Education"
+The Hon Andrew Gee MP,05/06/2022,,"Shadow Minister for Regional Health"
+The Hon Andrew Gee MP,05/06/2022,,"Shadow Minister for Regional Development, Local Government and Territories"
+Angie Bell MP,05/06/2022,,"Shadow Minister for Early Childhood Education"
+Angie Bell MP,05/06/2022,,"Shadow Minister for Youth"
+The Hon Nola Marino MP,05/06/2022,,"Shadow Assistant Minister for Education"
+The Hon Angus Taylor MP,05/06/2022,,"Shadow Treasurer"
+Senator Dean Smith,05/06/2022,,"Shadow Assistant Minister for Competition, Charities and Treasury"
+The Hon Paul Fletcher MP,05/06/2022,,"Shadow Minister for Government Services and the Digital Economy"
+The Hon Paul Fletcher MP,05/06/2022,,"Shadow Minister for Science and the Arts"
+The Hon Paul Fletcher MP,05/06/2022,,"Manager of Opposition Business in the House"
+The Hon Michael Sukkar MP,05/06/2022,,"Shadow Minister for Social Services"
+The Hon Michael Sukkar MP,05/06/2022,,"Shadow Minister for the National Disability Insurance Scheme"
+The Hon Michael Sukkar MP,05/06/2022,,"Shadow Minister for Housing"
+The Hon Michael Sukkar MP,05/06/2022,,"Shadow Minister for Homelessness"
+Pat Conaghan MP,05/06/2022,,"Shadow Assistant Minister for Social Services"
+Pat Conaghan MP,05/06/2022,,"Shadow Assistant Minister for the Prevention of Family Violence"
+The Hon Karen Andrews MP,05/06/2022,,"Shadow Minister for Home Affairs"
+The Hon Karen Andrews MP,05/06/2022,,"Shadow Minister for Child Protection and the Prevention of Family Violence"
+The Hon Dan Tehan MP,05/06/2022,,"Shadow Minister for Immigration and Citizenship"
+Senator James Paterson,05/06/2022,,"Shadow Minister for Cyber Security"
+Senator James Paterson,05/06/2022,,"Shadow Minister for Countering Foreign Interference"
+Senator the Hon Anne Ruston,05/06/2022,,"Shadow Minister for Health and Aged Care"
+Senator the Hon Anne Ruston,05/06/2022,,"Shadow Minister for Sport"
+Senator the Hon Anne Ruston,05/06/2022,,"Manager of Opposition Business in the Senate"
+Melissa McIntosh MP,05/06/2022,,"Shadow Assistant Minister for Mental Health and Suicide Prevention"
+Gavin Pearce MP,05/06/2022,,"Shadow Assistant Minister for Health, Aged Care and Indigenous Health Services"
+Senator the Hon Bridget McKenzie,05/06/2022,,"Shadow Minister for Infrastructure, Transport and Regional Development"
+Senator the Hon Bridget McKenzie,05/06/2022,,"Leader of the Nationals in the Senate"
+Senator the Hon Sarah Henderson,05/06/2022,,"Shadow Minister for Communications"
+Dr Anne Webster MP,05/06/2022,,"Shadow Assistant Minister for Regional Development"
+Tony Pasin MP,05/06/2022,,"Shadow Assistant Minister for Infrastructure and Transport"
+The Hon Andrew Hastie MP,05/06/2022,,"Shadow Minister for Defence"
+The Hon Luke Howarth MP,05/06/2022,,"Shadow Minister for Defence Industry"
+The Hon Luke Howarth MP,05/06/2022,,"Shadow Minister for Defence Personnel"
+Phillip Thompson OAM MP,05/06/2022,,"Shadow Assistant Minister for Defence"


### PR DESCRIPTION
I chose the date "01/06/2022" for when the previous shadow ministry ended, as that's the date the new Albanese ministry was released, and many of these former shadow ministry reps are now in the ministry.

I used "05/06/2022" for the new shadow ministry start date, as that's the date Dutton shadow ministry was released.