### PR TITLE
Lidia Thorpe becomes Independent, Jim Molan died

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -432,3 +432,4 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 944,,Sue Lines,,WA,26.7.2022,changed_party,,still_in_office,PRES
 945,,Andrew McLachlan,,SA,26.7.2022,changed_party,,still_in_office,DPRES
 946,,Lidia Thorpe,,Vic,6.2.2023,changed_party,,still_in_office,IND
+947,,Maria Kovacic,,NSW,31.5.2023,section_15,,still_in_office,LIB

--- a/data/senators.csv
+++ b/data/senators.csv
@@ -406,10 +406,10 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 919,,David Van,,Vic,1.7.2019,,,still_in_office,LIB
 920,,Jess Walsh,,Vic,1.7.2019,,,still_in_office,ALP
 921,,Sarah Henderson,,Vic,11.9.2019,section_15,,still_in_office,LIB
-922,,Jim Molan,,NSW,11.11.2019,section_15,,still_in_office,LIB
+922,,Jim Molan,,NSW,11.11.2019,section_15,16.1.2023,died,LIB
 923,,Andrew McLachlan,,SA,6.2.2020,section_15,26.7.2022,changed_party,LIB
 924,,Rex Patrick,,SA,10.8.2020,changed_party,21.5.2022,defeated,IND
-925,,Lidia Thorpe,,Vic,4.9.2020,section_15,,still_in_office,GRN
+925,,Lidia Thorpe,,Vic,4.9.2020,section_15,6.2.2023,changed_party,GRN
 926,,Ben Small,,WA,25.11.2020,section_15,21.5.2022,defeated,LIB
 927,,Dorinda Cox,,WA,14.9.2021,section_15,,still_in_office,GRN
 928,,Karen Grogan,,SA,21.9.2021,section_15,,still_in_office,ALP
@@ -431,3 +431,4 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 943,,Slade Brockman,,WA,26.7.2022,changed_party,,still_in_office,LIB
 944,,Sue Lines,,WA,26.7.2022,changed_party,,still_in_office,PRES
 945,,Andrew McLachlan,,SA,26.7.2022,changed_party,,still_in_office,DPRES
+946,,Lidia Thorpe,,Vic,6.2.2023,changed_party,,still_in_office,IND


### PR DESCRIPTION
On 6 Feb 2023, [Lidia Thorpe](https://en.wikipedia.org/wiki/Lidia_Thorpe) announced that she's leaving the Greens and will now sit as an Independent

On 16 Jan 2023, [Jim Molan](https://en.wikipedia.org/wiki/Jim_Molan) died. There is now a vacancy in the Senate for NSW.