### PR TITLE
Update people.csv

### DIFF
--- a/data/people.csv
+++ b/data/people.csv
@@ -1039,3 +1039,4 @@ person count,aph id,name,birthday,alt name
 1011,299352,Jana Stewart,,Jana Naretha Anne Stewart
 1012,300639,Tammy Tyrrell,,
 1013,IWK,Linda White,,
+1014,306168,Maria Kovacic,,


### PR DESCRIPTION
Maria Kovacic has replaced the late Jim Molan as NSW Senator