### PR TITLE
Update representatives.csv - Caldwell (Fadden) and Broadbent (Monash)

### DIFF
--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -764,7 +764,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 764,,Dave Sharma,Wentworth,NSW,18.05.2019,,21.5.2022,defeated,LIB
 # Members elected elsewhere in 2019 Federal election thanks to redistribution,,,,,,,,,
 765,,Steve Georganas,Adelaide,SA,18.05.2019,elected_elsewhere,,still_in_office,ALP
-766,,Russell Evan Broadbent,Monash,Vic,18.05.2019,elected_elsewhere,,still_in_office,LIB
+766,,Russell Evan Broadbent,Monash,Vic,18.05.2019,elected_elsewhere,14.11.2023,changed_party,LIB
 767,,Mark Christopher Butler,Hindmarsh,SA,18.05.2019,elected_elsewhere,,still_in_office,ALP
 768,,Nicholas David Champion,Spence,SA,18.05.2019,elected_elsewhere,22.02.2022,resigned,ALP
 769,,Andrew Wilkie,Clark,Tas,18.05.2019,elected_elsewhere,,still_in_office,IND
@@ -820,3 +820,5 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 817,,Mary Doyle,Aston,Vic,1.4.2023,,,still_in_office,ALP
 # New member elected in 2023 Fadden by-election
 818,,Cameron Caldwell,Fadden,Qld,15.7.2023,,,still_in_office,LNP
+# Member resigned to become independent
+819,,Russell Evan Broadbent,Monash,Vic,14.11.2023,changed_party,,still_in_office,IND

--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -438,7 +438,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 440,,Bernard Fernando Ripoll,Oxley,Qld,3.10.1998,,9.5.2016,retired,ALP
 441,,Amanda Louise Rishworth,Kingston,SA,24.11.2007,,,still_in_office,ALP
 442,,Andrew John Robb,Goldstein,Vic.,9.10.2004,,9.5.2016,retired,LIB
-443,,Stuart Rowland Robert,Fadden,Qld,24.11.2007,,,still_in_office,LIB
+443,,Stuart Rowland Robert,Fadden,Qld,24.11.2007,,18.5.2023,resigned,LIB
 444,,Eric Laidlaw Robinson,McPherson,Qld,2.12.1972,,7.1.1981,died,LIB
 445,,Ian Louis Robinson,Cowper,NSW,30.11.1963,,1.12.1984,elected_elsewhere,NPA
 446,,Ian Louis Robinson,Page,NSW,1.12.1984,,24.3.1990,defeated,NPA
@@ -818,3 +818,5 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 816,,Andrew Gee,Calare,NSW,23.12.2022,changed_party,,still_in_office,IND
 # New member elected in 2023 Aston by-election
 817,,Mary Doyle,Aston,Vic,1.4.2023,,,still_in_office,ALP
+# New member elected in 2023 Fadden by-election
+818,,Cameron Caldwell,Fadden,Qld,15.7.2023,,,still_in_office,LNP


### PR DESCRIPTION
Cameron Caldwell replaced Stuart Robert (who resigned) as MP for Fadden after a by-election in July.