### PR TITLE
Update senators.csv - Senator Van now IND

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -403,7 +403,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 916,,Paul Scarr,,Qld,1.7.2019,,,still_in_office,LIB
 917,,Tony Sheldon,,NSW,1.7.2019,,,still_in_office,ALP
 918,,Marielle Smith,,SA,1.7.2019,,,still_in_office,ALP
-919,,David Van,,Vic,1.7.2019,,,still_in_office,LIB
+919,,David Van,,Vic,1.7.2019,,19.6.2023,changed_party,LIB
 920,,Jess Walsh,,Vic,1.7.2019,,,still_in_office,ALP
 921,,Sarah Henderson,,Vic,11.9.2019,section_15,,still_in_office,LIB
 922,,Jim Molan,,NSW,11.11.2019,section_15,16.1.2023,died,LIB
@@ -433,3 +433,4 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 945,,Andrew McLachlan,,SA,26.7.2022,changed_party,,still_in_office,DPRES
 946,,Lidia Thorpe,,Vic,6.2.2023,changed_party,,still_in_office,IND
 947,,Maria Kovacic,,NSW,31.5.2023,section_15,,still_in_office,LIB
+948,,David Van,,Vic,19.6.2023,changed_party,,still_in_office,IND


### PR DESCRIPTION
David Van is now an independent.

From his [Senate homepage](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=283601):

* Independent. Served: 19.06.2023 to present
* Liberal Party of Australia. Served: 01.07.2019 to 19.06.2023