### PR TITLE
Update senators.csv - Sharma replaced Payne as NSW Liberal Senator

### DIFF
--- a/data/senators.csv
+++ b/data/senators.csv
@@ -175,7 +175,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 173,,John Horace Panizza,,WA,11.7.1987 ,,31.1.1997 ,died,LIB
 174,,Warwick Raymond Parer,,Qld,22.11.1984 ,section_15,11.2.2000 ,resigned,LIB
 175,,Stephen Shane Parry,,Tas.,1.7.2005,,3.7.2011,changed_party,LIB
-177,,Marise Ann Payne,,NSW,9.4.1997,section_15,,still_in_office,LIB
+177,,Marise Ann Payne,,NSW,9.4.1997,section_15,30.9.2023,resigned,LIB
 178,,Helen Beatrice Polley,,Tas.,1.7.2005,,,still_in_office,ALP
 179,,Janet Frances Powell,,Vic.,26.8.1986 ,section_15,30.6.1993 ,defeated,IND
 180,,Cyril Graham Primmer,,Vic.,1.7.1971 ,,30.6.1985 ,retired,ALP
@@ -434,3 +434,4 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 946,,Lidia Thorpe,,Vic,6.2.2023,changed_party,,still_in_office,IND
 947,,Maria Kovacic,,NSW,31.5.2023,section_15,,still_in_office,LIB
 948,,David Van,,Vic,19.6.2023,changed_party,,still_in_office,IND
+949,,Dave Sharma,,NSW,30.11.2023,section_15,,still_in_office,LIB


### PR DESCRIPTION
Senator [Marise Payne](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=M56) resigned 30/09/2023
Former MP [Dave Sharma](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=274506) was chosen to replace her 30/11/2023