### PR TITLE
Update representatives.csv - MPs for Dunkley and Cook

### DIFF
--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -822,3 +822,5 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 818,,Cameron Caldwell,Fadden,Qld,15.7.2023,,,still_in_office,LNP
 # Member resigned to become independent
 819,,Russell Evan Broadbent,Monash,Vic,14.11.2023,changed_party,,still_in_office,IND
+# New member elected in 2024 Dunkley by-election
+820,,Jodie Belyea,Dunkley,Vic,2.3.2024,,,still_in_office,ALP

--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -383,7 +383,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 385,,Allan Agapitos Morris,Newcastle,NSW,5.3.1983,,8.10.2001,retired,ALP
 386,,Peter Frederick Morris,Shortland,NSW,2.12.1972,,31.8.1998,retired,ALP
 387,,William Lawrence Morrison,St George,NSW,18.10.1980,,26.10.1984,retired,ALP
-388,,Scott John Morrison,Cook,NSW,24.11.2007,,,still_in_office,LIB
+388,,Scott John Morrison,Cook,NSW,24.11.2007,,28.2.2024,resigned,LIB
 389,,Frank William Mossfield,Greenway,NSW,2.3.1996,,31.8.2004,retired,ALP
 390,,John Graham Mountford,Banks,NSW,18.10.1980,,19.2.1990,retired,ALP
 391,,Judith Eleanor Moylan,Pearce,WA,13.3.1993,,5.8.2013,retired,LIB
@@ -743,7 +743,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 743,,Libby Coker,Corangamite,Vic,18.05.2019,,,still_in_office,ALP
 744,,Pat Conaghan,Cowper,NSW,18.05.2019,,,still_in_office,NP
 745,,Celia Hammond,Curtin,WA,18.05.2019,,21.5.2022,defeated,LIB
-746,,Peta Murphy,Dunkley,Vic,18.05.2019,,,still_in_office,ALP
+746,,Peta Murphy,Dunkley,Vic,18.05.2019,,4.12.2023,died,ALP
 747,,Daniel Mulino,Fraser,Vic,18.05.2019,,,still_in_office,ALP
 748,,Fiona Phillips,Gilmore,NSW,18.05.2019,,,still_in_office,ALP
 749,,Phillip Thompson,Herbert,QLD,18.05.2019,,,still_in_office,LNP

--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -824,3 +824,5 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 819,,Russell Evan Broadbent,Monash,Vic,14.11.2023,changed_party,,still_in_office,IND
 # New member elected in 2024 Dunkley by-election
 820,,Jodie Belyea,Dunkley,Vic,2.3.2024,,,still_in_office,ALP
+# New member elected in 2024 Cook by-election
+821,,Simon Kennedy,Cook,NSW,13.04.2024,,,still_in_office,LIB


### PR DESCRIPTION
MP Murphy (Dunkley) [has died in office](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=133646). A by-election has taken place and [Jodie Belyea](https://en.wikipedia.org/wiki/Jodie_Belyea) was elected as of 2 March, but the aph website has not yet created a page for her.

MP Morrison (Cook) [has resigned](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=E3L) and a [Cook by-election](https://en.wikipedia.org/wiki/2024_Cook_by-election) will be held, though the date is still to be confirmed.