### PR TITLE
Update representatives.csv - Goodenough Independent

### DIFF
--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -658,7 +658,7 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 660,,David Gillespie,Lyne,NSW,7.9.2013,,,still_in_office,NP
 661,,Eric Hutchinson,Lyons,Tas,7.9.2013,,2.7.2016,defeated,LIB
 662,,Andrew Broad,Mallee,Vic,7.9.2013,,18.05.2019,retired,NP
-663,,Ian Goodenough,Moore,WA,7.9.2013,,,still_in_office,LIB
+663,,Ian Goodenough,Moore,WA,7.9.2013,,31.12.2024,changed_party,LIB
 664,,Barnaby Joyce,New England,NSW,7.9.2013,,27.10.2017,disqualified,NP
 665,,Sharon Claydon,Newcastle,NSW,7.9.2013,,,still_in_office,ALP
 666,,Rick Wilson,O'Connor,WA,7.9.2013,,,still_in_office,LIB
@@ -826,3 +826,5 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 820,,Jodie Belyea,Dunkley,Vic,2.3.2024,,,still_in_office,ALP
 # New member elected in 2024 Cook by-election
 821,,Simon Kennedy,Cook,NSW,13.04.2024,,,still_in_office,LIB
+# Member resigned to become independent
+822,,Ian Goodenough,Moore,WA,31.12.2024,changed_party,,still_in_office,IND


### PR DESCRIPTION
It seems I missed [Ian Goodenough](https://www.aph.gov.au/Senators_and_Members/Parliamentarian?MPID=74046) becoming an independent at the end of last year.