### PR TITLE
Fixes import of logger

### DIFF
--- a/sitemap.rb
+++ b/sitemap.rb
@@ -6,6 +6,7 @@
 
 $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
+require "logger"
 require "rubygems"
 require "active_record"
 require "builder"


### PR DESCRIPTION
Older versions of concurrent-ruby were importing this for us, but not anymore So, adding a require

We're not using rails, but we are using some of the active* gems.
see https://github.com/rails/rails/issues/54271