### PR TITLE
Add a first guess at links for 2025 election

### DIFF
--- a/parse-member-links.rb
+++ b/parse-member-links.rb
@@ -161,6 +161,23 @@ x.consinfos do
     href = "https://www.abc.net.au/news/elections/federal/2022/results/senate"
     x.consinfo("canonical" => canonical, "abc_election_results_2022" => href)
   end
+  
+  puts "Election results 2025 (from the abc.net.au)..."
+  abc_root = "https://www.abc.net.au"
+  url = "#{abc_root}/news/elections/federal/2025/guide/electorates"
+  doc = agent.get(url)
+
+  doc.search("td.electorate a").each do |a|
+    href = doc.uri + a["href"]
+    name = a.inner_text.strip
+    x.consinfo("canonical" => name, "abc_election_results_2025" => href)
+  end
+
+  %w[NSW Victoria Queensland WA SA Tasmania ACT NT].each do |canonical|
+    # No seperate url for each state results... So...
+    href = "https://www.abc.net.au/news/elections/federal/2025/results/senate"
+    x.consinfo("canonical" => canonical, "abc_election_results_2025" => href)
+  end  
 end
 xml.close
 


### PR DESCRIPTION
https://oaf.slack.com/archives/C4BLHGGC8/p1763000948274149

> Brenda
 [12:29] this in the logs every day makes me think nobody ever imported an election in 2025.
> ```
> Web pages, social media URLs and email from APH (via Morph)...
> Election results 2007 (from the abc.net.au) ...
> Election results 2010 (from the abc.net.au) ...
> Election results 2013 (from the abc.net.au)...
> Election results 2016 (from the abc.net.au)...
> Election results 2019 (from the abc.net.au)...
> Election results 2022 (from the abc.net.au)...
> ```

First attempt at importing 2025 election results. Superficially it seems as though it's similar to 2022 so I've made minimum changes. May need to tweak the target for the lower house electorates.