### PR TITLE
Feature use twfy's bin/run to run its code and provide a bin/run for others to run our code

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ Called from the OpenAustralia.org web application (twfy - another git submodule 
 
 * `#{web_root}/rblib/config.rb` - required by `lib/configuration.rb`
   * `#{web_root}/twfy/conf/general` - used by MySociety::Config.set_file (can override in configuration.yml)
-* `perl #{conf.web_root}/twfy/scripts/xml2db.pl` - called by `parse-speeches.rb`
-* `#{conf.web_root}/twfy/scripts/mpinfoin.pl links` (perl) - called by `wikipedia.rb`
-* `perl #{conf.web_root}/twfy/scripts/xml2db.pl` (perl) - called by `parse-members.rb` (Use `--no-load` to skip)
-* `#{conf.web_root}/twfy/scripts/mpinfoin.pl` (perl) - called by `parse-member-links.rb`
+* `#{conf.web_root}/twfy/bin/run scripts/xml2db.pl` - called by `parse-speeches.rb`
+* `#{conf.web_root}/twfy/bin/run scripts/mpinfoin.pl links` (perl) - called by `wikipedia.rb`
+* `#{conf.web_root}/twfy/bin/run scripts/xml2db.pl` (perl) - called by `parse-members.rb` (Use `--no-load` to skip)
+* `#{conf.web_root}/twfy/bin/run scripts/mpinfoin.pl` (perl) - called by `parse-member-links.rb`
 
 ## USAGE for Developers
 

--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+cd "$(dirname "$0")/.." || exit 1
+
+case "${1:-}" in
+  *.rb)
+    RUNNER="ruby"
+    ;;
+  *.pl)
+    exec perl "$@"
+    ;;
+  *.php)
+    export PATH="/usr/local/bin:/usr/bin:/software/bin:/opt/bin:/opt/php/bin:$PATH"
+    exec php "$@"
+    ;;
+  rake|script/console|script/dbconsole|bin/rake)
+    RUNNER="$1"
+    ;;
+  *)
+#    echo "Usage: $0 <script.rb|script.pl|script.php> [args...]" >&2
+#    exit 1
+    RUNNER="rake"
+    ;;
+esac
+
+if command -v mise &>/dev/null; then
+  exec mise exec -- bundle exec "$RUNNER" "$@"
+elif [ -f "$HOME/.rvm/scripts/rvm" ]; then
+  source "$HOME/.rvm/scripts/rvm"
+  exec rvm . exec bundle exec "$RUNNER" "$@"
+elif [ -f "/usr/local/rvm/scripts/rvm" ]; then
+  source "/usr/local/rvm/scripts/rvm"
+  exec rvm . exec bundle exec "$RUNNER" "$@"
+else
+  exec bundle exec "$RUNNER" "$@"
+fi
+

--- a/parse-members.rb
+++ b/parse-members.rb
@@ -92,7 +92,7 @@ class ParseMembers
     people.write_xml("#{output_dir}/people.xml", "#{output_dir}/representatives.xml", "#{output_dir}/senators.xml",
                      "#{output_dir}/ministers.xml", "#{output_dir}/divisions.xml")
 
-    command = "perl #{conf.web_root}/twfy/scripts/xml2db.pl --members --all --force"
+    command = "#{conf.web_root}/twfy/bin/run scripts/xml2db.pl --members --all --force"
     if options[:load_database]
       # And load up the database
       # Starts with 'perl' to be friendly with Windows

--- a/parse-speeches.rb
+++ b/parse-speeches.rb
@@ -155,7 +155,7 @@ class ParseSpeeches
     command_options << " --force" if options[:force]
 
     # Starts with 'perl' to be friendly with Windows
-    command = "perl #{conf.web_root}/twfy/scripts/xml2db.pl #{command_options}"
+    command = "#{conf.web_root}/twfy/bin/run scripts/xml2db.pl #{command_options}"
     if options[:load_database]
       system(command)
     else


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

Changed the call to use bin/run from the parser

This allows the parser to control what ruby version is used to run its own code, thus decoupling the language version dependencies and allowing me to advance parser without having to tell other repos.

## Why was this needed?

The projects where too tightly coupled.

## Implementation/Deploy Steps (Optional)

Update openaustralia submodule commits and deploy

## Notes to reviewer (Optional)
