### PR TITLE
Add rbenv to bin/run and check first

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -23,7 +23,15 @@ case "${1:-}" in
     ;;
 esac
 
-if command -v mise &>/dev/null; then
+# Put the ruby manager used by openaustralia/Capfile first
+if [ -x "$HOME/.rbenv/bin/rbenv" ]; then
+  export PATH="$HOME/.rbenv/bin:$PATH"
+  eval "$(rbenv init -)"
+  exec bundle exec "$RUNNER" "$@"
+elif command -v rbenv &>/dev/null; then
+  eval "$(rbenv init -)"
+  exec bundle exec "$RUNNER" "$@"
+elif command -v mise &>/dev/null; then
   exec mise exec -- bundle exec "$RUNNER" "$@"
 elif [ -f "$HOME/.rvm/scripts/rvm" ]; then
   source "$HOME/.rvm/scripts/rvm"


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

Adds rbenv detection to bin/run.

## Why was this needed?

Because capistrano uses rbenv, but the deploy user is set up with rvm, so production
```
deploy@ip-172-31-43-242:/srv/www/production/current$ type ruby
ruby is /usr/local/rvm/rubies/ruby-3.1.7/bin/ruby
```
And staging both use rvm:
```
deploy@ip-172-31-35-36:/srv/www/staging/current$ type ruby
ruby is hashed (/usr/local/rvm/rubies/ruby-3.4.9/bin/ruby)
deploy@ip-172-31-35-36:/srv/www/staging/current$ cat .ruby-version 
3.4.9
```
which is **not** what capistrano was configured with:
```
deploy@ip-172-31-35-36:/srv/www/staging/current$ egrep -n 'rvm|rbenv' Capfile config/deploy.rb
Capfile:7:require 'capistrano/rbenv'
config/deploy.rb:6:# Ruby/rbenv configuration
config/deploy.rb:7:set :rbenv_type, :user
config/deploy.rb:8:set :rbenv_ruby, File.read('.ruby-version').strip
```

And thus capistrano would have updated rbenv's version of ruby, not rvm's!

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
