### PR TITLE
Handle rspec not present on servers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,12 +2,16 @@
 
 require "fileutils"
 require "rake"
-require "rspec/core/rake_task"
 
 require_relative "lib/configuration"
 
-task default: [:spec]
+begin
+  require "rspec/core/rake_task"
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+  task(:spec) { puts "rspec not available" }
+end
 
-RSpec::Core::RakeTask.new(:spec)
+task default: [:spec]
 
 Dir["lib/tasks/*.rake"].each { |f| load f }


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

Fixes 
```
ianh@ben:.../openaustralia (ians-staging)$ make staging-parse-members
bundle exec cap staging parse:members
00:00 parse:members
      01 bash -c openaustralia-parser/bin/run parse-members.rb
      01 rake aborted!
      01 LoadError: cannot load such file -- rspec/core/rake_task (LoadError)
```

## Why was this needed?

because that is the next step in the deployment list

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
