### PR TITLE
Correct the script standalone run line in a number of scripts

### DIFF
--- a/member-images.rb
+++ b/member-images.rb
@@ -43,3 +43,5 @@ class MemberImages
 end
 
 MemberImages.new(ARGV).run if $PROGRAM_NAME == __FILE__
+
+

--- a/parse-member-links.rb
+++ b/parse-member-links.rb
@@ -279,3 +279,4 @@ class ParseMemberLinks
 end
 
 ParseMemberLinks.new(ARGV).run if $PROGRAM_NAME == __FILE__
+

--- a/parse-members.rb
+++ b/parse-members.rb
@@ -104,4 +104,5 @@ class ParseMembers
   end
 end
 
-MemberImages.new(ARGV).run if $PROGRAM_NAME == __FILE__
+ParseMembers.new(ARGV).run if $PROGRAM_NAME == __FILE__
+

--- a/parse-postcodes.rb
+++ b/parse-postcodes.rb
@@ -55,5 +55,5 @@ class ParsePostcodes
   end
 end
 
-MemberImages.new(ARGV).run if $PROGRAM_NAME == __FILE__
+ParsePostcodes.new(ARGV).run if $PROGRAM_NAME == __FILE__
 

--- a/parse-postcodes_2010.rb
+++ b/parse-postcodes_2010.rb
@@ -94,4 +94,5 @@ class ParsePostcodes2010
   end
 end
 
-MemberImages.new(ARGV).run if $PROGRAM_NAME == __FILE__
+ParsePostcodes2010.new(ARGV).run if $PROGRAM_NAME == __FILE__
+

--- a/parse-speeches.rb
+++ b/parse-speeches.rb
@@ -165,3 +165,5 @@ class ParseSpeeches
   end
 end
 
+ParseSpeeches.new.run if $PROGRAM_NAME == __FILE__
+

--- a/postcodes.rb
+++ b/postcodes.rb
@@ -68,4 +68,4 @@ class Postcodes
   end
 end
 
-exit Postcodes.new(ARGV).run.to_i if $PROGRAM_NAME == __FILE__
+Postcodes.new.run if $PROGRAM_NAME == __FILE__

--- a/register-split.rb
+++ b/register-split.rb
@@ -123,4 +123,4 @@ class RegisterSplit
   end
 end
 
-exit RegisterSplit.new(ARGV).run if $PROGRAM_NAME == __FILE__
+RegisterSplit.new.run if $PROGRAM_NAME == __FILE__

--- a/sitemap.rb
+++ b/sitemap.rb
@@ -20,3 +20,4 @@ $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
 require "sitemap_generator"
 
+SitemapGenerator.new.run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

Correct the actual line to call the run method if the scripts are called standalone rather than from a test

## Why was this needed?

This is the one line that isnt tested when you require these classes and then call them from a test, and embarrassingly I missed fixing some of them up as I replicated the pattern.

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
