### PR TITLE
Fix parse-speeches wrong number of arguments error when run as script

### DIFF
--- a/parse-speeches.rb
+++ b/parse-speeches.rb
@@ -165,5 +165,4 @@ class ParseSpeeches
   end
 end
 
-ParseSpeeches.new.run if $PROGRAM_NAME == __FILE__
-
+ParseSpeeches.new(ARGV).run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/794

## What does this do?

Fix parse-speeches wrong number of arguments error when run as script

## Why was this needed?

Script fails to run

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
