### PR TITLE
read ARGV to initialise the parser

### DIFF
--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -16,8 +16,9 @@ require "sitemap_generator/sitemap_url"
 class SitemapGenerator
   attr_reader :base_dir
 
-  def initialize(args)
-    @args = args
+  def initialize(args = ARGV)
+    # OptionParser#parse! mutates the array, so copy caller-provided args.
+    @args = args.dup
     @options = {}
     OptionParser.new do |opts|
       opts.banner = "Usage: sitemap.rb [--output-dir=PATH]"

--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -16,9 +16,7 @@ require "sitemap_generator/sitemap_url"
 class SitemapGenerator
   attr_reader :base_dir
 
-  def initialize(args = ARGV)
-    # OptionParser#parse! mutates the array, so copy caller-provided args.
-    @args = args.dup
+  def initialize(args)
     @options = {}
     OptionParser.new do |opts|
       opts.banner = "Usage: sitemap.rb [--output-dir=PATH]"

--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -17,6 +17,7 @@ class SitemapGenerator
   attr_reader :base_dir
 
   def initialize(args)
+    @args = args
     @options = {}
     OptionParser.new do |opts|
       opts.banner = "Usage: sitemap.rb [--output-dir=PATH]"

--- a/sitemap.rb
+++ b/sitemap.rb
@@ -20,4 +20,6 @@ $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
 require "sitemap_generator"
 
-SitemapGenerator.new(ARGV.dup).run if $PROGRAM_NAME == __FILE__
+args = ARGV.dup # make a copy of ARGV so that OptionParser doesn't modify the original
+
+SitemapGenerator.new(args).run if $PROGRAM_NAME == __FILE__

--- a/sitemap.rb
+++ b/sitemap.rb
@@ -20,4 +20,4 @@ $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
 require "sitemap_generator"
 
-SitemapGenerator.new.run if $PROGRAM_NAME == __FILE__
+SitemapGenerator.new(ARGV.dup).run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
fixes one of the errors in https://github.com/openaustralia/openaustralia/issues/793

## Why was this needed?
```
/srv/www/production/releases/20260521061631/openaustralia-parser/lib/sitemap_generator.rb:19:in 'initialize': wrong number of arguments (given 0, expected 1) (ArgumentError)
	from sitemap.rb:23:in 'Class#new'
	from sitemap.rb:23:in '<main>'
```
