### PR TITLE
Remove redundant column from David Farley's entry in representatives.csv

### DIFF
--- a/data/representatives.csv
+++ b/data/representatives.csv
@@ -867,4 +867,4 @@ member count,person count,name,Division,State/Territory,Date of election,Type of
 856,,Barnaby Joyce,New England,NSW,27.11.2025,changed_party,8.12.2025,changed_party,IND
 857,,Barnaby Joyce,New England,NSW,8.12.2025,changed_party,,still_in_office,PHON
 # Farrer By-Election
-858,,David Farley,Farrer,NSW,09.05.2026,by_election,,,still_in_office,PHON
+858,,David Farley,Farrer,NSW,09.05.2026,by_election,,still_in_office,PHON


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/openaustralia/issues/866
- https://github.com/openaustralia/openaustralia-parser/pull/245

## What does this do?
Removes a redundant column from David Farley's entry in the representatives.csv file.

## Why was this needed?
The redundant column was causign errors in data processing.

## Implementation/Deploy Steps (Optional)
1. Merge this PR
2. Update the Submodule in https://github.com/openaustralia/openaustralia
3. Deploy https://github.com/openaustralia/openaustralia

## Notes to reviewer (Optional)

