### PR TITLE
Doc/manual security check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,9 +20,11 @@ gem "rmagick"
 gem "ruby-progressbar"
 
 group :development do
+  gem "bundle-audit", require: false
   gem "rubocop", require: false #  "~> 1.7",
   gem "rubocop-rake"
   gem "rubocop-rspec"
+  gem "ruby_audit", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,11 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     builder (3.3.0)
+    bundle-audit (0.2.0)
+      bundler-audit
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crack (1.0.1)
@@ -129,6 +134,8 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
+    ruby_audit (3.1.0)
+      bundler-audit (~> 0.9.0)
     rubyntlm (0.6.5)
       base64
     securerandom (0.4.1)
@@ -144,6 +151,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
+    thor (1.5.0)
     timecop (0.9.11)
     timeout (0.6.1)
     tzinfo (2.0.6)
@@ -166,6 +174,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 8.0.4)
   builder (~> 3.0)
+  bundle-audit
   csv
   hpricot
   htmlentities
@@ -182,6 +191,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   ruby-progressbar
+  ruby_audit
   simplecov
   simplecov-console
   timecop

--- a/README.md
+++ b/README.md
@@ -386,6 +386,18 @@ detail in this helpful email from mySociety's Matthew Somerville.
 > ATB,
 > Matthew
 
+## To run style and coding checks
+
+    bundle exec rubocop
+
+## To check for security updates
+
+Either check [Dependabot alerts](https://github.com/openaustralia/openaustralia-parser/security/dependabot)
+for the main branch, taking note of when the last check was run, **or** run manually on current branch:
+
+    bundle exec ruby-audit
+    bundle exec bundle-audit
+
 ## Gotchas
 
 ### `count` is used as an identifier but isn't how many of anything


### PR DESCRIPTION
## Description

Document manual security check

## Motivation and Context
Dependabot doesn't check ruby versions and it differs from how bundle checks related gems

This is in preparation of performing security updates much faster than individual merge of dependabot PRs when there are a number of them.

## How Has This Been Tested?
Ran the commands as documented (only applicable to local dev system)
on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0

Marked ready for review since github checks passed.

## Screenshots (if appropriate):

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.