### PR TITLE
Fix/895 uninitialized constant in optionparser in sitemap generator

### DIFF
--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -1,15 +1,16 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "configuration"
+require "optparse"
 
-require "sitemap_generator/comment"
-require "sitemap_generator/counted_file"
-require "sitemap_generator/hansard"
-require "sitemap_generator/member"
-require "sitemap_generator/news"
-require "sitemap_generator/sitemap"
-require "sitemap_generator/sitemap_url"
+require_relative "configuration"
+require_relative "sitemap_generator/comment"
+require_relative "sitemap_generator/counted_file"
+require_relative "sitemap_generator/hansard"
+require_relative "sitemap_generator/member"
+require_relative "sitemap_generator/news"
+require_relative "sitemap_generator/sitemap"
+require_relative "sitemap_generator/sitemap_url"
 
 # Generate sitemap.xml for quick and easy search engine updating
 # This is run as part of twfy/scripts/morningupdate

--- a/lib/sitemap_generator/sitemap.rb
+++ b/lib/sitemap_generator/sitemap.rb
@@ -1,3 +1,5 @@
+require "fileutils"
+
 class SitemapGenerator
   class Sitemap
     # These are limits that are imposed on a single sitemap file by the specification

--- a/spec/scripts/sitemap_spec.rb
+++ b/spec/scripts/sitemap_spec.rb
@@ -10,14 +10,15 @@
 # No --no-load needed (no perl/php calls).
 # No VCR needed (no external HTTP — all DB reads).
 
-require_relative "../spec_helper"
-
+require "nokogiri"
 require "fileutils"
 
+require_relative "../spec_helper"
 require_relative "../../sitemap"
 
 RSpec.describe "sitemap.rb", :integration do
-  let(:script) { File.expand_path("../../sitemap.rb", __dir__) }
+  let(:script) { "sitemap.rb" }
+  let(:script_path) { File.expand_path("../../#{script}", __dir__) }
   let(:output_dir) { File.expand_path("../../tmp/output/sitemap", __dir__) }
   # A trailing slash is required
   let(:args) { %W[--output-dir #{output_dir}/] }
@@ -26,9 +27,47 @@ RSpec.describe "sitemap.rb", :integration do
   after { FileUtils.rm_rf(output_dir) }
 
   it "loads without syntax errors" do
-    output = `ruby -c #{script} 2>&1`
+    output = `ruby -c #{script_path} 2>&1`
     expect($CHILD_STATUS.exitstatus).to eq(0)
     expect(output).to match(/Syntax OK/)
+  end
+
+  it "runs without errors" do
+    output = `bin/run #{script} #{args.join(" ")} 2>&1`
+    expect($CHILD_STATUS.exitstatus).to eq(0),
+                                        "Failed (non zero status: #{$CHILD_STATUS.exitstatus}) " \
+                                          "with output:\n#{output}"
+    expect(output).to match(/Done! sitemap generated under/)
+  end
+
+  def parse_sitemap_index(path)
+    Nokogiri::XML(File.read(path)) { |cfg| cfg.strict }
+  end
+
+  it "sitemap.xml has one <sitemap> entry per generated file" do
+    output = `bin/run #{script} #{args.join(" ")} 2>&1`
+    doc = parse_sitemap_index(File.join(output_dir, "sitemap.xml"))
+    locs = doc.remove_namespaces!.xpath("//sitemap/loc").map(&:text)
+
+    gz_files = Dir.glob(File.join(output_dir, "sitemaps", "*.xml.gz")).sort
+
+    expect(locs.length).to eq(gz_files.length)
+    locs.each do |loc|
+      filename = File.basename(URI.parse(loc).path)
+      expect(File).to exist(File.join(output_dir, "sitemaps", filename)), "Had output:\n#{output}"
+    end
+  end
+
+  it "each sitemap file is valid gzip and well-formed urlset XML" do
+    output = `bin/run #{script} #{args.join(" ")} 2>&1`
+    Dir.glob(File.join(output_dir, "sitemaps", "*.xml.gz")).each do |gz_path|
+      xml = Zlib::GzipReader.open(gz_path) { |f| f.read }
+      doc = Nokogiri::XML(xml) { |cfg| cfg.strict }
+      expect(doc.errors).to be_empty, "Had output:\n#{output}"
+      expect(doc.root.name).to eq("urlset"), "Had output:\n#{output}"
+      expect(doc.root.namespace.href).to eq("http://www.sitemaps.org/schemas/sitemap/0.9"),
+                                         "Had output:\n#{output}"
+    end
   end
 
   describe "uses db", :db do


### PR DESCRIPTION
## Description

* Update spec to check sitemap actualy runs stand alone
* Update sitemap_generator.rb to require utilities used and use require_relative when appropriate

## Motivation and Context

Fix cron jobs failing:
* https://github.com/openaustralia/openaustralia/issues/895

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system - extended spec and ran `bundle exec rake`

Developed and tested on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0, make 4.3

Added specs to: spec/scripts/sitemap_spec.rb to reproduce error, then fixed and then tested all specs:
```
Finished in 41.65 seconds (files took 1.14 seconds to load)
237 examples, 0 failures

Coverage report generated for RSpec to /home/ianh/Projects/OpenAustralia/openaustralia_repos/openaustralia-parser/coverage.
Line Coverage: 78.67% (2202 / 2799)

COVERAGE:  78.67% -- 2202/2799 lines in 45 files
```

- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) - sitemaps will now be present for google and other indexing bots (as intended)
- [ ] Documentation

## Checklist:

- [ ] My code follows the code style of this project. - Actually I recommend the use of require_relative instead of relying on LOAD_PATH for internal references! See https://medium.com/@alvaroflara/requiring-code-in-ruby-fcb934d4fb8c
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
