### PR TITLE
Refactored to always use AphMechanizeAgent.new_agent when accessing aph site

### DIFF
--- a/lib/aph_mechanize_agent.rb
+++ b/lib/aph_mechanize_agent.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "mechanize"
+
 module AphMechanizeAgent
   # We've been kindly given a special user agent to use so that our traffic
   # isn't blocked by the application firewall of aph.gov.au.

--- a/lib/aph_mechanize_agent.rb
+++ b/lib/aph_mechanize_agent.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module AphMechanizeAgent
+  # We've been kindly given a special user agent to use so that our traffic
+  # isn't blocked by the application firewall of aph.gov.au.
+  # See https://mail.missiveapp.com/#search/aph.gov.au/conversations/4f0a0161-421e-4d0b-9dd1-49275353acf7/messages/bc27bcd1-2cba-5e63-64d3-a364037629a2
+  USER_AGENT = "Mozilla/5.0+AppleWebKit/537.36+(KHTML,+like+Gecko;+compatible;+Amazonbot/0.1;++https://developer.amazon.com/support/amazonbot)+Chrome/119.0.6045.214+Safari/537.36"
+
+  # Returns a Mechanize agent configured with the UA aph.gov.au has asked us to use.
+  def self.new_agent
+    agent = Mechanize.new
+    agent.user_agent = USER_AGENT
+    agent
+  end
+end

--- a/lib/hansard_parser.rb
+++ b/lib/hansard_parser.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
-require "speech"
-require "mechanize"
-require "configuration"
-require "debates"
-require "builder_alpha_attributes"
-require "house"
-require "people_image_downloader"
 require "log4r"
-require "hansard_day"
-require "hansard_rewriter"
-require "patch"
+
+require_relative "aph_mechanize_agent"
+require_relative "speech"
+require_relative "configuration"
+require_relative "debates"
+require_relative "builder_alpha_attributes"
+require_relative "house"
+require_relative "people_image_downloader"
+require_relative "hansard_day"
+require_relative "hansard_rewriter"
+require_relative "patch"
 
 class UnknownSpeaker
   def initialize(name)
@@ -54,12 +55,7 @@ class HansardParser
   # Returns nil it it doesn't exist
   # This is the original data without any patches applied at this end
   def unpatched_hansard_xml_source_data_on_date(date, house)
-    agent = Mechanize.new
-    # We've been kindly given a special user agent to use so
-    # that our traffic isn't blocked by the application firewall
-    # of aph.gov.au.
-    # See https://mail.missiveapp.com/#search/aph.gov.au/conversations/4f0a0161-421e-4d0b-9dd1-49275353acf7/messages/bc27bcd1-2cba-5e63-64d3-a364037629a2
-    agent.user_agent = "Mozilla/5.0+AppleWebKit/537.36+(KHTML,+like+Gecko;+compatible;+Amazonbot/0.1;++https://developer.amazon.com/support/amazonbot)+Chrome/119.0.6045.214+Safari/537.36"
+    agent = AphMechanizeAgent.new_agent
 
     # This is the page returned by Parlinfo Search for that day
     url = "https://parlinfo.aph.gov.au/parlInfo/search/display/display.w3p;adv=yes;orderBy=_fragment_number,doc_date-rev;page=0;query=Dataset%3Ahansard#{house.representatives? ? 'r' : 's'},hansard#{house.representatives? ? 'r' : 's'}80%20Date%3A#{date.day}%2F#{date.month}%2F#{date.year};rec=0;resCount=Default"

--- a/lib/people_image_downloader.rb
+++ b/lib/people_image_downloader.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require "rmagick"
-require "mechanize"
-
-require "configuration"
-require "name"
 require "hpricot"
 require "English"
+
+require_relative "aph_mechanize_agent"
+require_relative "configuration"
+require_relative "name"
 
 # TODO: Rename class
 class PeopleImageDownloader
@@ -30,13 +30,7 @@ class PeopleImageDownloader
     Hpricot.buffer_size = 262144
 
     @conf = Configuration.new
-    @agent = Mechanize.new
-
-    # We've been kindly given a special user agent to use so
-    # that our traffic isn't blocked by the application firewall
-    # of aph.gov.au.
-    # See https://mail.missiveapp.com/#search/aph.gov.au/conversations/4f0a0161-421e-4d0b-9dd1-49275353acf7/messages/bc27bcd1-2cba-5e63-64d3-a364037629a2
-    @agent.user_agent = "Mozilla/5.0+AppleWebKit/537.36+(KHTML,+like+Gecko;+compatible;+Amazonbot/0.1;++https://developer.amazon.com/support/amazonbot)+Chrome/119.0.6045.214+Safari/537.36"
+    @agent = AphMechanizeAgent.new_agent
   end
 
   def download(people, small_image_dir, large_image_dir, extra_large_image_dir, limit: nil)

--- a/parse-member-links.rb
+++ b/parse-member-links.rb
@@ -12,9 +12,10 @@ require "json"
 require "optparse"
 require "fileutils"
 
-require "name"
-require "people"
-require "configuration"
+require_relative "lib/aph_mechanize_agent"
+require_relative "lib/name"
+require_relative "lib/people"
+require_relative "lib/configuration"
 
 class ParseMemberLinks
   def initialize(args)
@@ -43,6 +44,7 @@ class ParseMemberLinks
     # Not using caching proxy since we will be running this script once a day and we
     # always want to get the new data
     agent = Mechanize.new
+    aph_agent = AphMechanizeAgent.new_agent
 
     puts "Reading member data..."
     people = PeopleCSVReader.read_members
@@ -218,7 +220,7 @@ class ParseMemberLinks
 
     puts "Parsing Register of interests from APH..."
 
-    page = agent.get("https://www.aph.gov.au/Senators_and_Members/Members/Register")
+    page = aph_agent.get("https://www.aph.gov.au/Senators_and_Members/Members/Register")
     representatives_data = []
     page.search("table.documents").each do |table|
       table.search("tbody tr").each do |tr|


### PR DESCRIPTION
## Description

* Drys up code and applies the fix from two other calls to parse-members-links
* Uses requires_relative to clarify what are external libraries vs internal files

## Motivation and Context

APH has a WAF that prohibits unrecognised browsers

Fixes:
* https://github.com/openaustralia/openaustralia/issues/888

## How Has This Been Tested?

Tested manually on dev system:
```bash
$ bin/run parse-member-links.rb --no-load --output-dir=tmp/
/home/ianh/.local/share/mise/installs/ruby/3.4.9/lib/ruby/gems/3.4.0/gems/bundler-2.4.19/lib/bundler/rubygems_ext.rb:241: warning: already initialized constant Gem::Platform::JAVA
...
/home/ianh/.local/share/mise/installs/ruby/3.4.9/lib/ruby/site_ruby/3.4.0/rubygems/platform.rb:288: warning: previous definition of X64_LINUX_MUSL was here
Loading config from: /home/ianh/Projects/OpenAustralia/openaustralia_repos/openaustralia-parser/lib/../configuration.yml for development
Reading member data...
Web pages, social media URLs and email from APH (via Morph)...
Writing to tmp//websites.xml ...
Writing to tmp//links-abc-election.xml ...
Election results 2007 (from the abc.net.au) ...
Election results 2010 (from the abc.net.au) ...
Election results 2013 (from the abc.net.au)...
Election results 2016 (from the abc.net.au)...
Election results 2019 (from the abc.net.au)...
Election results 2022 (from the abc.net.au)...
Election results 2025 (from the abc.net.au)...
Parsing Register of interests from APH...
WARNING: Couldn't find Ley, Ms Sussan (Found one person by name, but not current, last period 2001-11-10 resigned 2026-02-27 - see data/*.csv)
Writing to tmp//links-register-of-interests.xml ...
No-load option has disabled the following that is normally run:
  ../openaustralia/twfy/scripts/mpinfoin.pl links
```

- [x] Checked affected area manually on my own / staging system

Developed and tested on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0, make 4.3

- [x] Ran automated tests on my own system
```
Finished in 38.01 seconds (files took 1.14 seconds to load)
234 examples, 0 failures

Coverage report generated for RSpec to /home/ianh/Projects/OpenAustralia/openaustralia_repos/openaustralia-parser/coverage.
Line Coverage: 78.7% (2206 / 2803)

COVERAGE:  78.70% -- 2206/2803 lines in 46 files
```
- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [ ] My code follows the code style of this project. (Changing code style: use require_relative for local files, requires for external libraries to make it more obvious)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
