### PR TITLE
Feature/888 complete require relative transition

### DIFF
--- a/create_patch.rb
+++ b/create_patch.rb
@@ -11,8 +11,8 @@ require "optparse"
 require "date"
 require "fileutils"
 
-require "people_csv_reader"
-require "hansard_parser"
+require_relative "lib/people_csv_reader"
+require_relative "lib/hansard_parser"
 
 class CreatePatch
   def initialize(args)

--- a/export-comments.rb
+++ b/export-comments.rb
@@ -9,7 +9,7 @@ $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
 require "csv"
 
-require "configuration"
+require_relative "lib/configuration"
 require "mysql"
 
 class ExportComments

--- a/import-comments.rb
+++ b/import-comments.rb
@@ -11,7 +11,7 @@ $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
 require "csv"
 
-require "configuration"
+require_relative "lib/configuration"
 require "mysql"
 
 class ImportComments

--- a/lib/debates.rb
+++ b/lib/debates.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require "heading"
-require "speech"
-require "division"
-require "count"
+require_relative "heading"
+require_relative "speech"
+require_relative "division"
+require_relative "count"
 
 # Holds the data for debates on one day
 # Also knows how to output the XML data for that

--- a/lib/division.rb
+++ b/lib/division.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "section"
+require_relative "section"
 
 class Division < Section
   def initialize(yes_members:, no_members:, yes_tellers:, no_tellers:, pairs:, time:, url:, bills:, count:, division_count:, date:, house:, logger: nil)

--- a/lib/hansard_day.rb
+++ b/lib/hansard_day.rb
@@ -2,10 +2,10 @@
 
 # vim: set ts=2 sw=2 et sts=2 ai:
 
-require "hpricot_additions"
-require "house"
-require "hansard_division"
-require "hansard_speech"
+require_relative "hpricot_additions"
+require_relative "house"
+require_relative "hansard_division"
+require_relative "hansard_speech"
 require "date"
 
 # Use this for sections of the Hansard that we're not currently supporting. Allows us to track

--- a/lib/hansard_rewriter.rb
+++ b/lib/hansard_rewriter.rb
@@ -2,7 +2,7 @@
 
 # vim: set ts=2 sw=2 et sts=2 ai:
 
-require "hpricot_additions"
+require_relative "hpricot_additions"
 
 class HansardRewriter
   attr_reader :logger

--- a/lib/hansard_speech.rb
+++ b/lib/hansard_speech.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "hpricot_additions"
-require "name"
+require_relative "hpricot_additions"
+require_relative "name"
 require "English"
 
 class HansardSpeech

--- a/lib/people.rb
+++ b/lib/people.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require "people_csv_reader"
-require "people_xml_writer"
-require "people_image_downloader"
-require "house"
+require_relative "people_csv_reader"
+require_relative "people_xml_writer"
+require_relative "people_image_downloader"
+require_relative "house"
 
 class People < Array
   def initialize

--- a/lib/people_csv_reader.rb
+++ b/lib/people_csv_reader.rb
@@ -2,10 +2,10 @@
 
 require "csv"
 require "ostruct"
-require "date_with_future"
-require "people"
-require "person"
-require "name"
+require_relative "date_with_future"
+require_relative "people"
+require_relative "person"
+require_relative "name"
 
 # Utility used by regression test
 class PeopleCSVReader

--- a/lib/people_xml_writer.rb
+++ b/lib/people_xml_writer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "builder_alpha_attributes"
+require_relative "builder_alpha_attributes"
 
 class PeopleXMLWriter
   def self.write(people:, people_filename:, members_filename:, senators_filename:, ministers_filename:, divisions_filename:)

--- a/lib/person.rb
+++ b/lib/person.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "period"
-require "house"
+require_relative "period"
+require_relative "house"
 
 class Person
   attr_reader :periods, :person_count, :name, :alternate_names, :minister_positions, :birthday,

--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -4,6 +4,7 @@
 require "optparse"
 
 require_relative "configuration"
+
 require_relative "sitemap_generator/comment"
 require_relative "sitemap_generator/counted_file"
 require_relative "sitemap_generator/hansard"

--- a/lib/speech.rb
+++ b/lib/speech.rb
@@ -2,7 +2,7 @@
 
 require "hpricot"
 require "htmlentities"
-require "section"
+require_relative "section"
 
 class Speech < Section
   attr_accessor :speaker, :content, :interjection, :continuation,

--- a/member-images.rb
+++ b/member-images.rb
@@ -6,8 +6,8 @@ require "bundler/setup"
 $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
 require "optparse"
-require "configuration"
-require "people"
+require_relative "lib/configuration"
+require_relative "lib/people"
 
 class MemberImages
   def initialize(args)

--- a/parse-members.rb
+++ b/parse-members.rb
@@ -6,8 +6,8 @@ require "bundler/setup"
 $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 require "optparse"
 
-require "configuration"
-require "people"
+require_relative "lib/configuration"
+require_relative "lib/people"
 
 class ParseMembers
   def initialize(args)

--- a/parse-postcodes.rb
+++ b/parse-postcodes.rb
@@ -9,7 +9,7 @@ require "optparse"
 require "fileutils"
 require "mechanize"
 
-require "configuration"
+require_relative "lib/configuration"
 
 class ParsePostcodes
   def initialize(args)

--- a/parse-postcodes_2010.rb
+++ b/parse-postcodes_2010.rb
@@ -7,7 +7,7 @@ $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
 require "mechanize"
 
-require "people"
+require_relative "lib/people"
 
 class ParsePostcodes2010
   def initialize(args)

--- a/parse-speeches.rb
+++ b/parse-speeches.rb
@@ -7,9 +7,9 @@ $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 require "optparse"
 require "ruby-progressbar"
 
-require "people"
-require "hansard_parser"
-require "configuration"
+require_relative "lib/people"
+require_relative "lib/hansard_parser"
+require_relative "lib/configuration"
 
 class ParseSpeeches
   def initialize(args)

--- a/postcodes.rb
+++ b/postcodes.rb
@@ -9,8 +9,8 @@ $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
 require "csv"
 require "mysql2"
-require "configuration"
-require "people"
+require_relative "lib/configuration"
+require_relative "lib/people"
 require "optparse"
 
 class Postcodes

--- a/register-split.rb
+++ b/register-split.rb
@@ -13,9 +13,9 @@ require "csv"
 
 $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
-require "configuration"
-require "name"
-require "people"
+require_relative "lib/configuration"
+require_relative "lib/name"
+require_relative "lib/people"
 
 class RegisterSplit
   PageRange = Struct.new(:filename, :start, :end)

--- a/sitemap.rb
+++ b/sitemap.rb
@@ -18,7 +18,7 @@ require "zlib"
 
 $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
-require "sitemap_generator"
+require_relative "lib/sitemap_generator"
 
 args = ARGV.dup # make a copy of ARGV so that OptionParser doesn't modify the original
 


### PR DESCRIPTION
## Description

Followed Ben's suggestion: The require_relative migration is only partly applied

Three lib files and one root script now use require_relative, but lib/people.rb:5 still has require "people_image_downloader", and roughly a dozen other root scripts still rely on $LOAD_PATH.unshift. parse-member-links.rb now carries both the $LOAD_PATH.unshift at line 6 and require_relative "lib/..." at lines 15 to 18.

The convention is a good one and I am happy for it to land here, it just leaves the tree in a mixed state that is harder to reason about than either end point. Either finish the sweep in a follow-up PR, or note the convention in the README so the next person knows which way to write new requires. No change needed in this PR.

For what it is worth, I checked that mixing the two does not double-load: require "name" and require_relative "lib/name" both resolve to the same absolute path in $LOADED_FEATURES, so there is no duplicate-load hazard.

## Motivation and Context

Consistency in code

Work done because of:
* https://github.com/openaustralia/openaustralia/issues/888

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system

Developed and tested on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0, make 4.3

Ran 
```
$ bundle exec rake
...
Finished in 37.94 seconds (files took 1.14 seconds to load)
234 examples, 0 failures

Coverage report generated for RSpec to /home/ianh/Projects/OpenAustralia/openaustralia_repos/openaustralia-parser/coverage.
Line Coverage: 78.71% (2207 / 2804)

COVERAGE:  78.71% -- 2207/2804 lines in 46 files
```

- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality) - code standard change to make it obvious what is internal and what is a gem
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project. (As updated)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
