### PR TITLE
Add AGENTS.md for AI coding agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot instructions
+
+See [AGENTS.md](../AGENTS.md) for repository guidance. It applies here too.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,9 +82,12 @@ This repository has no `CONTRIBUTING.md` or templates of its own; the org-wide o
 [`openaustralia/.github`](https://github.com/openaustralia/.github) apply. Fetch the current versions rather than
 relying on a copy:
 
-`gh api repos/openaustralia/.github/contents/.github/CONTRIBUTING.md -H "Accept: application/vnd.github.raw"`
+`curl -fsSL https://raw.githubusercontent.com/openaustralia/.github/main/.github/CONTRIBUTING.md`
 
-`gh api repos/openaustralia/.github/contents/AGENTS.md -H "Accept: application/vnd.github.raw"`
+`curl -fsSL https://raw.githubusercontent.com/openaustralia/.github/main/AGENTS.md`
+
+Any equivalent fetch of those URLs works (web fetch, or `gh api` if the GitHub CLI
+is installed); don't assume a particular tool is present.
 
 After merging a change here, the umbrella repository's submodule pointer needs bumping before production picks it
 up.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, GitHub Copilot, and others) when working with code in
+this repository. `CLAUDE.md` and `.github/copilot-instructions.md` point here so the guidance lives in one place.
+
+## What this repository is
+
+The OpenAustralia Hansard parser: Ruby scripts that parse Hansard from the Australian Parliament and load it into
+the OpenAustralia.org.au database. It is consumed as a git submodule of
+[`openaustralia/openaustralia`](https://github.com/openaustralia/openaustralia) (the umbrella repository), and in
+production is driven by the `twfy` app's cron scripts (`dailyupdate` runs `parse-member-links.rb` nightly;
+`morningupdate` runs `parse-speeches.rb previous-working-day` then `sitemap.rb` on weekdays).
+
+## Setup
+
+Ruby 3.4.9 (`.ruby-version`).
+
+```
+mise install
+bundle install
+cp configuration.yml.example configuration.yml
+```
+
+- `configuration.yml` is gitignored and **required before anything runs, including `bundle exec rake`** - the
+  Rakefile loads `lib/configuration.rb`, which reads it unconditionally.
+- Its defaults assume a sibling umbrella checkout (`web_root: "../openaustralia"`) and reach into
+  `rblib/config.rb` and `twfy/conf/general` there. For standalone development, uncomment the "Standalone
+  development override" keys in the example so you don't need twfy or PHP at all (see README).
+- The example file has placeholder `morph_api_key` / `theyvoteforyou_api_key` values; real keys belong only in the
+  gitignored `configuration.yml`, never in a commit.
+- The `hpricot` gem needs a compiler workaround on modern toolchains, and `.bundle/` is gitignored, so on a fresh
+  clone run `bundle config build.hpricot --with-cflags=-Wno-error=incompatible-function-pointer-types` before
+  `bundle install`.
+- A local MySQL database is needed for the load scripts; the exact `CREATE DATABASE`/`CREATE USER` statements are
+  in the README.
+
+## Commands
+
+```
+bundle exec rake                     # default task: the RSpec suite
+bundle exec rspec spec/lib/name_spec.rb
+bundle exec rubocop
+bundle exec ruby-audit / bundle exec bundle-audit
+bundle exec ./parse-members.rb --test   # data-file sanity checks, no DB writes
+bundle exec ./postcodes.rb --test
+bundle exec rake db:stats / db:backup / db:validate_encoding
+script/console                       # loads lib/**/*.rb into IRB
+```
+
+`bin/run <script>` is the production wrapper (picks the Ruby manager, dispatches .rb/.pl/.php); you don't need it
+locally.
+
+## Structure
+
+- Top-level `*.rb` scripts are the entry points; the daily ones are `parse-speeches.rb`, `parse-member-links.rb`
+  and `sitemap.rb`. `lib/` holds the parser proper (`hansard_parser.rb`, `hansard_rewriter.rb`, `people.rb`, ...).
+- `data/*.csv` (people, representatives, senators, ministers, shadow-ministers) are **maintained by hand** for
+  by-elections, party changes and reshuffles - a routine workflow here, not an anomaly. The most common parser
+  failure is an unrecognised person in a division; the fix is usually a data file edit (see README).
+- `xml_schemas/*.rnc` are RELAX NG schemas for the XML the parser emits; `spec/` uses RSpec with VCR cassettes.
+- `docs/` is an empty scaffold - not a documentation source.
+
+## Gotchas
+
+- **Hpricot is still the primary HTML parser** (six `lib/` files plus `parse-member-links.rb`); Nokogiri appears in
+  exactly one file. Draft PR #253 converts `ParseMemberLinks` only. Don't add new Hpricot usage, and don't do a
+  wholesale conversion as a side effect of another change - it touches the specs too.
+- **No CI runs yet.** There is no `.github/workflows/`; the checked-in `.travis.yml` is dead (pins Ruby 2.7.2
+  against `.ruby-version` 3.4.9) and draft PR #252 adds GitHub Actions. A green local run is currently the only
+  gate, so run the spec suite and RuboCop yourself.
+- `APP_ENV` is inferred from the working directory path (`/production/` or `/staging/` in `Dir.pwd`), defaulting to
+  development; specs force `test`.
+- `export-comments.rb` / `import-comments.rb` `require "mysql"`, which isn't in the Gemfile (`mysql2` is), and
+  refuse to run without the `BE-DANGEROUS` env var - treat them as broken until fixed.
+- `wikipedia.rb` is an empty file despite being listed in the README's dependencies.
+- Scripts that load the database write to production-shaped tables; anything run with a real `configuration.yml`
+  pointed at production paths is a live action needing an explicit go-ahead.
+
+## Contributing
+
+This repository has no `CONTRIBUTING.md` or templates of its own; the org-wide ones in
+[`openaustralia/.github`](https://github.com/openaustralia/.github) apply. Fetch the current versions rather than
+relying on a copy:
+
+`gh api repos/openaustralia/.github/contents/.github/CONTRIBUTING.md -H "Accept: application/vnd.github.raw"`
+
+`gh api repos/openaustralia/.github/contents/AGENTS.md -H "Accept: application/vnd.github.raw"`
+
+After merging a change here, the umbrella repository's submodule pointer needs bumping before production picks it
+up.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Description

Adds AGENTS.md documenting the parser: setup (configuration.yml is required before even rake runs, the hpricot build flag, standalone vs umbrella config), commands, the hand-maintained data CSV workflow, how output feeds twfy, and the sharp edges - Hpricot still primary (#253 converts one class), no CI yet (#252 adds Actions; .travis.yml is dead), APP_ENV inferred from the working directory, and the broken comments scripts.

Part of an org-wide pass standardising agent-instruction files: canonical content in AGENTS.md, CLAUDE.md and .github/copilot-instructions.md as pointers, org rules referenced via live fetch rather than copied (see openaustralia/.github#14).

## Motivation and Context

Agents (and new contributors) had no starting context in this repo; every claim in the new file was verified against the actual files rather than inherited from memory or older docs.

## How Has This Been Tested?

- [x] I have checked the affected area on my own system - documentation only; commands and file claims verified against the repository contents
- [ ] I have run relevant automated tests on my own system
- [ ] I have confirmed it passed the GitHub actions tests

## Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

---

AI disclosure: written with Claude Code (model claude-fable-5), reviewed by a human before merge.